### PR TITLE
feat(cmd): implement CommandContext pattern for dependency injection

### DIFF
--- a/cmd/context.go
+++ b/cmd/context.go
@@ -1,0 +1,88 @@
+// Package cmd provides the command-line interface for opnDossier.
+package cmd
+
+import (
+	"context"
+
+	"github.com/EvilBit-Labs/opnDossier/internal/config"
+	"github.com/EvilBit-Labs/opnDossier/internal/log"
+	"github.com/spf13/cobra"
+)
+
+// CommandContext encapsulates shared state for all CLI commands.
+// It is set on the cobra.Command context during PersistentPreRunE
+// and provides explicit dependency injection for configuration and logging.
+//
+// This pattern replaces direct access to package-level globals,
+// making dependencies explicit and testing easier.
+type CommandContext struct {
+	// Config holds the application's configuration loaded from file, environment, or flags.
+	Config *config.Config
+
+	// Logger is the application's structured logger instance.
+	Logger *log.Logger
+}
+
+// contextKey is the type for context keys to avoid collisions with other packages.
+type contextKey string
+
+// cmdContextKey is the key used to store CommandContext in context.Context.
+const cmdContextKey contextKey = "opnDossierCmdContext"
+
+// GetCommandContext retrieves the CommandContext from a cobra.Command's context.
+// Returns nil if the context is not set or does not contain a CommandContext.
+//
+// Example usage in a command's RunE function:
+//
+//	func runMyCommand(cmd *cobra.Command, args []string) error {
+//	    cmdCtx := GetCommandContext(cmd)
+//	    if cmdCtx == nil {
+//	        return errors.New("command context not initialized")
+//	    }
+//	    cmdCtx.Logger.Info("running command")
+//	    // use cmdCtx.Config, cmdCtx.Logger
+//	}
+func GetCommandContext(cmd *cobra.Command) *CommandContext {
+	if cmd == nil {
+		return nil
+	}
+	ctx := cmd.Context()
+	if ctx == nil {
+		return nil
+	}
+	cmdCtx, ok := ctx.Value(cmdContextKey).(*CommandContext)
+	if !ok {
+		return nil
+	}
+	return cmdCtx
+}
+
+// SetCommandContext stores the CommandContext in the command's context.
+// If the command's context is nil, a new background context is created.
+//
+// This should be called in PersistentPreRunE of the root command to make
+// the context available to all subcommands.
+func SetCommandContext(cmd *cobra.Command, cmdCtx *CommandContext) {
+	if cmd == nil {
+		return
+	}
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx = context.WithValue(ctx, cmdContextKey, cmdCtx)
+	cmd.SetContext(ctx)
+}
+
+// MustGetCommandContext retrieves the CommandContext from a cobra.Command's context
+// and panics if it is not found. Use this only when you are certain the context
+// has been set (e.g., after PersistentPreRunE has run).
+//
+// For most cases, prefer GetCommandContext and handle the nil case explicitly.
+func MustGetCommandContext(cmd *cobra.Command) *CommandContext {
+	cmdCtx := GetCommandContext(cmd)
+	if cmdCtx == nil {
+		panic("command context not initialized - ensure PersistentPreRunE has run")
+	}
+	return cmdCtx
+}

--- a/cmd/context_test.go
+++ b/cmd/context_test.go
@@ -1,0 +1,168 @@
+package cmd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/EvilBit-Labs/opnDossier/internal/config"
+	"github.com/EvilBit-Labs/opnDossier/internal/log"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetCommandContext_ValidContext(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.SetContext(context.Background())
+
+	expectedCfg := &config.Config{Verbose: true}
+	expectedLogger, err := log.New(log.Config{Level: "info"})
+	require.NoError(t, err)
+
+	cmdCtx := &CommandContext{
+		Config: expectedCfg,
+		Logger: expectedLogger,
+	}
+
+	SetCommandContext(cmd, cmdCtx)
+
+	result := GetCommandContext(cmd)
+	require.NotNil(t, result)
+	assert.Equal(t, expectedCfg, result.Config)
+	assert.Equal(t, expectedLogger, result.Logger)
+}
+
+func TestGetCommandContext_NilCommand(t *testing.T) {
+	result := GetCommandContext(nil)
+	assert.Nil(t, result)
+}
+
+func TestGetCommandContext_NilContext(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	// Don't set context
+
+	result := GetCommandContext(cmd)
+	assert.Nil(t, result)
+}
+
+func TestGetCommandContext_MissingKey(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.SetContext(context.Background())
+	// Don't set CommandContext
+
+	result := GetCommandContext(cmd)
+	assert.Nil(t, result)
+}
+
+func TestGetCommandContext_WrongType(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	// Set a different type with the same key
+	ctx := context.WithValue(context.Background(), cmdContextKey, "not a CommandContext")
+	cmd.SetContext(ctx)
+
+	result := GetCommandContext(cmd)
+	assert.Nil(t, result)
+}
+
+func TestSetCommandContext_NilCommand(t *testing.T) {
+	cmdCtx := &CommandContext{}
+
+	// Should not panic
+	require.NotPanics(t, func() {
+		SetCommandContext(nil, cmdCtx)
+	})
+}
+
+func TestSetCommandContext_NilContext(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	// Don't set context on command
+
+	cmdCtx := &CommandContext{
+		Config: &config.Config{},
+	}
+
+	SetCommandContext(cmd, cmdCtx)
+
+	// Should have created a new context and stored the value
+	result := GetCommandContext(cmd)
+	require.NotNil(t, result)
+	assert.Equal(t, cmdCtx.Config, result.Config)
+}
+
+// testContextKey is a typed key for testing context preservation.
+type testContextKey string
+
+func TestSetCommandContext_ExistingContext(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	const otherKey testContextKey = "other-key"
+	existingCtx := context.WithValue(context.Background(), otherKey, "other-value")
+	cmd.SetContext(existingCtx)
+
+	cmdCtx := &CommandContext{
+		Config: &config.Config{Verbose: true},
+	}
+
+	SetCommandContext(cmd, cmdCtx)
+
+	// Should preserve existing context values
+	assert.Equal(t, "other-value", cmd.Context().Value(otherKey))
+
+	// And also have the CommandContext
+	result := GetCommandContext(cmd)
+	require.NotNil(t, result)
+	assert.True(t, result.Config.Verbose)
+}
+
+func TestMustGetCommandContext_ValidContext(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.SetContext(context.Background())
+
+	cmdCtx := &CommandContext{
+		Config: &config.Config{},
+	}
+	SetCommandContext(cmd, cmdCtx)
+
+	require.NotPanics(t, func() {
+		result := MustGetCommandContext(cmd)
+		assert.NotNil(t, result)
+	})
+}
+
+func TestMustGetCommandContext_NilContext_Panics(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	// Don't set context
+
+	assert.Panics(t, func() {
+		MustGetCommandContext(cmd)
+	})
+}
+
+func TestMustGetCommandContext_MissingKey_Panics(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.SetContext(context.Background())
+	// Don't set CommandContext
+
+	assert.Panics(t, func() {
+		MustGetCommandContext(cmd)
+	})
+}
+
+func TestCommandContext_FieldAccess(t *testing.T) {
+	cfg := &config.Config{
+		Verbose:    true,
+		Quiet:      false,
+		OutputFile: "test.md",
+	}
+	logger, err := log.New(log.Config{Level: "debug"})
+	require.NoError(t, err)
+
+	cmdCtx := &CommandContext{
+		Config: cfg,
+		Logger: logger,
+	}
+
+	assert.True(t, cmdCtx.Config.Verbose)
+	assert.False(t, cmdCtx.Config.Quiet)
+	assert.Equal(t, "test.md", cmdCtx.Config.OutputFile)
+	assert.NotNil(t, cmdCtx.Logger)
+}

--- a/cmd/convert_test.go
+++ b/cmd/convert_test.go
@@ -211,7 +211,7 @@ func TestBuildConversionOptionsWrapWidthPrecedence(t *testing.T) {
 		require.NoError(t, flags.Set("no-wrap", "true"))
 		sharedNoWrap = true
 		sharedWrapWidth = -1
-		require.NoError(t, validateConvertFlags(flags))
+		require.NoError(t, validateConvertFlags(flags, nil))
 	}
 
 	tests := []struct {
@@ -344,7 +344,7 @@ func TestValidateConvertFlagsNoWrapMutualExclusivity(t *testing.T) {
 				sharedWrapWidth = wrapVal
 			}
 
-			err := validateConvertFlags(flags)
+			err := validateConvertFlags(flags, nil)
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErrSubstr)

--- a/cmd/display.go
+++ b/cmd/display.go
@@ -102,10 +102,18 @@ Examples:
 			ctx = context.Background()
 		}
 
+		// Get configuration and logger from CommandContext
+		cmdCtx := GetCommandContext(cmd)
+		if cmdCtx == nil {
+			return errors.New("command context not initialized")
+		}
+		cmdLogger := cmdCtx.Logger
+		cmdConfig := cmdCtx.Config
+
 		filePath := args[0]
 
 		// Create context-aware logger with input file field
-		ctxLogger := logger.WithContext(ctx).WithFields("input_file", filePath)
+		ctxLogger := cmdLogger.WithContext(ctx).WithFields("input_file", filePath)
 
 		// Sanitize the file path
 		cleanPath := filepath.Clean(filePath)
@@ -147,7 +155,7 @@ Examples:
 			return fmt.Errorf("failed to parse XML from %s: %w", filePath, err)
 		}
 
-		mdOpts := buildDisplayOptions(Cfg)
+		mdOpts := buildDisplayOptions(cmdConfig)
 		g, err := converter.NewMarkdownGenerator(ctxLogger, mdOpts)
 		if err != nil {
 			ctxLogger.Error("Failed to create markdown generator", "error", err)

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -3,6 +3,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -53,6 +54,13 @@ Examples:
 			ctx = context.Background()
 		}
 
+		// Get logger from CommandContext
+		cmdCtx := GetCommandContext(cmd)
+		if cmdCtx == nil {
+			return errors.New("command context not initialized")
+		}
+		cmdLogger := cmdCtx.Logger
+
 		var wg sync.WaitGroup
 		errs := make(chan error, len(args))
 		validationFailed := false
@@ -63,7 +71,7 @@ Examples:
 				defer wg.Done()
 
 				// Create context-aware logger for this goroutine with input file field
-				ctxLogger := logger.WithContext(ctx).WithFields("input_file", fp)
+				ctxLogger := cmdLogger.WithContext(ctx).WithFields("input_file", fp)
 				ctxLogger.Info("Starting validation process")
 
 				// Sanitize the file path

--- a/project_spec/issue_140_spec.md
+++ b/project_spec/issue_140_spec.md
@@ -1,0 +1,355 @@
+# Technical Specification: Issue #140
+
+## Architecture: Reduce Global State in cmd Package with CommandContext Pattern
+
+**Issue URL:** https://github.com/EvilBit-Labs/opnDossier/issues/140 **Milestone:** v1.2 (Performance & Enterprise Features) **Labels:** enhancement, architecture, refactoring
+
+---
+
+## Issue Summary
+
+The `cmd` package uses package-level global variables with `//nolint:gochecknoglobals` directives. While this is acceptable for Cobra patterns, it creates hidden dependencies and makes testing harder.
+
+---
+
+## Problem Statement
+
+### Current State
+
+The `cmd` package declares 24 package-level variables across three files:
+
+**`cmd/root.go` (lines 17-36):**
+
+```go
+var (
+    cfgFile string                // CLI config file path
+    Cfg    *config.Config         // Application configuration
+    logger *log.Logger            // Application logger
+    buildDate = "unknown"         // Build information
+    gitCommit = "unknown"         // Build information
+)
+var defaultLoggerConfig = log.Config{...}  // Logger config
+var rootCmd = &cobra.Command{...}          // Root command
+```
+
+**`cmd/convert.go` (lines 27-40):**
+
+```go
+var (
+    outputFile string  // Output file path
+    format     string  // Output format
+    force      bool    // Force overwrite
+)
+var ErrOperationCancelled = errors.New(...)
+var ErrFailedToEnrichConfig = errors.New(...)
+var ErrUnsupportedOutputFormat = errors.New(...)
+var convertCmd = &cobra.Command{...}
+```
+
+**`cmd/shared_flags.go` (lines 9-17):**
+
+```go
+var (
+    sharedSections        []string  // Sections to include
+    sharedTheme           string    // Theme for rendering
+    sharedWrapWidth       = -1      // Text wrap width
+    sharedNoWrap          bool      // Disable text wrapping
+    sharedIncludeTunables bool      // Include system tunables
+    sharedComprehensive   bool      // Comprehensive report
+)
+```
+
+**`cmd/display.go` (line 34):**
+
+```go
+var displayCmd = &cobra.Command{...}
+```
+
+**`cmd/validate.go` (line 20):**
+
+```go
+var validateCmd = &cobra.Command{...}
+```
+
+### Problems
+
+1. **Hidden Dependencies:** Commands implicitly depend on global state that can be modified from anywhere
+2. **Testing Challenges:** Tests require careful setup/teardown of global variables (seen in test files with `t.Cleanup` patterns)
+3. **Data Flow Opacity:** Harder to trace how configuration flows through the application
+4. **Concurrency Risks:** While current tests handle this, global state in concurrent tests needs careful coordination
+5. **Mock Injection Difficulty:** Requires modifying globals rather than passing test doubles
+
+---
+
+## Technical Approach
+
+### Design: CommandContext Pattern
+
+Introduce a `CommandContext` struct that encapsulates shared state:
+
+```go
+// CommandContext encapsulates shared state for all CLI commands.
+// It is set on the cobra.Command context during PersistentPreRunE.
+type CommandContext struct {
+    Config *config.Config
+    Logger *log.Logger
+}
+
+// contextKey is the type for context keys to avoid collisions.
+type contextKey string
+
+// cmdContextKey is the key used to store CommandContext in context.Context.
+const cmdContextKey contextKey = "opnDossierCmdContext"
+
+// GetCommandContext retrieves the CommandContext from a cobra.Command.
+// Returns nil if not found.
+func GetCommandContext(cmd *cobra.Command) *CommandContext {
+    if ctx := cmd.Context(); ctx != nil {
+        if cmdCtx, ok := ctx.Value(cmdContextKey).(*CommandContext); ok {
+            return cmdCtx
+        }
+    }
+    return nil
+}
+
+// SetCommandContext stores the CommandContext in the command's context.
+func SetCommandContext(cmd *cobra.Command, cmdCtx *CommandContext) {
+    ctx := context.WithValue(cmd.Context(), cmdContextKey, cmdCtx)
+    cmd.SetContext(ctx)
+}
+```
+
+### Migration Strategy
+
+**Phase 1:** Introduce `CommandContext` alongside existing globals (backward compatible) **Phase 2:** Migrate commands to use context pattern **Phase 3:** Remove deprecated globals (keep only essential Cobra patterns)
+
+### What Stays Global (Acceptable Cobra Patterns)
+
+- `rootCmd`, `convertCmd`, `displayCmd`, `validateCmd` - Cobra command definitions
+- `buildDate`, `gitCommit` - Build-time ldflags injection
+- `defaultLoggerConfig` - Test override hook
+- Sentinel errors (`ErrOperationCancelled`, etc.)
+
+### What Moves to CommandContext
+
+- `Cfg` (configuration)
+- `logger` (application logger)
+- Flag variables (`outputFile`, `format`, `force`, `sharedSections`, etc.)
+
+---
+
+## Implementation Plan
+
+### Task 1: Create CommandContext Infrastructure
+
+**File:** `cmd/context.go` (new file)
+
+1. Define `CommandContext` struct
+2. Define `contextKey` type and constant
+3. Implement `GetCommandContext()` function
+4. Implement `SetCommandContext()` function
+5. Add tests in `cmd/context_test.go`
+
+**Acceptance Criteria:**
+
+- New file created with proper package declaration
+- All functions documented with Go doc comments
+- Tests cover normal and edge cases
+- `just lint` passes
+- `just test` passes
+
+### Task 2: Migrate Root Command Setup
+
+**File:** `cmd/root.go`
+
+1. Modify `PersistentPreRunE` to create and set `CommandContext`
+2. Keep `GetLogger()` and `GetConfig()` for backward compatibility (deprecated)
+3. Add deprecation comments directing to context pattern
+4. Update tests in `cmd/root_test.go`
+
+**Acceptance Criteria:**
+
+- CommandContext is set during PersistentPreRunE
+- Existing tests continue to pass
+- GetLogger/GetConfig work but are marked deprecated
+- `just ci-check` passes
+
+### Task 3: Migrate Convert Command
+
+**File:** `cmd/convert.go`
+
+1. Add `ConvertFlags` struct to hold convert-specific flags
+2. Modify `RunE` to get logger/config from CommandContext
+3. Remove direct access to global `logger` and `Cfg`
+4. Update `buildConversionOptions` to accept CommandContext
+5. Update tests in `cmd/convert_test.go`
+
+**Acceptance Criteria:**
+
+- Convert command uses CommandContext for config/logger
+- No direct access to global Cfg/logger in RunE
+- All existing tests pass
+- `just ci-check` passes
+
+### Task 4: Migrate Display Command
+
+**File:** `cmd/display.go`
+
+1. Modify `RunE` to get logger/config from CommandContext
+2. Update `buildDisplayOptions` to accept CommandContext
+3. Remove direct access to globals
+4. Update tests in `cmd/display_test.go`
+
+**Acceptance Criteria:**
+
+- Display command uses CommandContext
+- All existing tests pass
+- `just ci-check` passes
+
+### Task 5: Migrate Validate Command
+
+**File:** `cmd/validate.go`
+
+1. Modify `RunE` to get logger/config from CommandContext
+2. Remove direct access to global `logger`
+3. Update tests
+
+**Acceptance Criteria:**
+
+- Validate command uses CommandContext
+- All existing tests pass
+- `just ci-check` passes
+
+### Task 6: Consolidate Shared Flags
+
+**File:** `cmd/shared_flags.go`
+
+1. Create `SharedFlags` struct to hold shared flag values
+2. Add method to extract SharedFlags from CommandContext
+3. Update `addSharedTemplateFlags` to bind to context
+4. Update all consumers
+
+**Acceptance Criteria:**
+
+- SharedFlags struct exists with all shared flag values
+- Commands extract flags from context, not globals
+- `just ci-check` passes
+
+### Task 7: Final Cleanup and Documentation
+
+**Files:** All cmd/\*.go files, AGENTS.md
+
+1. Remove deprecated globals (Cfg, logger exports)
+2. Remove `//nolint:gochecknoglobals` where no longer needed
+3. Update AGENTS.md with CommandContext pattern documentation
+4. Ensure all tests pass
+5. Run full CI check
+
+**Acceptance Criteria:**
+
+- No unnecessary global variables remain
+- Documentation updated
+- `just ci-check` passes
+- All tests pass including race detection
+
+---
+
+## Test Plan
+
+### Unit Tests
+
+1. **Context Tests (`cmd/context_test.go`):**
+
+   - Test `GetCommandContext` with valid context
+   - Test `GetCommandContext` with nil context
+   - Test `GetCommandContext` with missing key
+   - Test `SetCommandContext` properly stores context
+
+2. **Command Integration Tests:**
+
+   - Verify CommandContext is available in PreRunE
+   - Verify CommandContext is available in RunE
+   - Test context propagation to subcommands
+
+3. **Backward Compatibility Tests:**
+
+   - Ensure GetLogger() still works (deprecated)
+   - Ensure GetConfig() still works (deprecated)
+
+### Race Detection
+
+```bash
+go test -race ./cmd/...
+```
+
+### Coverage Target
+
+Maintain >80% coverage on cmd package.
+
+---
+
+## Files to Modify/Create
+
+### New Files
+
+| File                  | Purpose                                    |
+| --------------------- | ------------------------------------------ |
+| `cmd/context.go`      | CommandContext struct and helper functions |
+| `cmd/context_test.go` | Tests for context functionality            |
+
+### Modified Files
+
+| File                       | Changes                                                                       |
+| -------------------------- | ----------------------------------------------------------------------------- |
+| `cmd/root.go`              | Create/set CommandContext in PersistentPreRunE, deprecate GetLogger/GetConfig |
+| `cmd/root_test.go`         | Add context-aware tests                                                       |
+| `cmd/convert.go`           | Use CommandContext instead of globals                                         |
+| `cmd/convert_test.go`      | Update tests to use context pattern                                           |
+| `cmd/display.go`           | Use CommandContext instead of globals                                         |
+| `cmd/display_test.go`      | Update tests if needed                                                        |
+| `cmd/validate.go`          | Use CommandContext instead of globals                                         |
+| `cmd/shared_flags.go`      | Create SharedFlags struct                                                     |
+| `cmd/shared_flags_test.go` | Update tests for SharedFlags                                                  |
+| `AGENTS.md`                | Document CommandContext pattern                                               |
+
+---
+
+## Success Criteria
+
+1. **Reduced Global State:** Only acceptable Cobra patterns remain as globals
+2. **Explicit Dependencies:** Commands receive context explicitly via CommandContext
+3. **Easier Testing:** Tests can inject mock contexts without global state manipulation
+4. **Clear Data Flow:** Configuration and logger flow is traceable through context
+5. **All Tests Pass:** Including race detection
+6. **CI Green:** `just ci-check` passes
+7. **Documentation Updated:** AGENTS.md includes CommandContext guidance
+
+---
+
+## Out of Scope
+
+1. **Restructuring cmd package into multiple packages** - Keep single package
+2. **Changing Cobra command registration pattern** - Commands stay as package-level vars
+3. **Modifying how ldflags injection works** - buildDate/gitCommit stay global
+4. **Changing sentinel error definitions** - Errors stay as package-level vars
+5. **Performance optimization** - This is a refactoring task
+6. **Adding new CLI commands or flags** - Scope limited to existing functionality
+
+---
+
+## Risk Assessment
+
+| Risk                                      | Mitigation                                                         |
+| ----------------------------------------- | ------------------------------------------------------------------ |
+| Breaking existing tests                   | Phase migration, maintain backward compatibility during transition |
+| Introducing bugs in command execution     | Comprehensive test coverage, race detection                        |
+| Merge conflicts with parallel development | Keep changes atomic, avoid large PRs                               |
+| CI failures                               | Run `just ci-check` at each phase                                  |
+
+---
+
+## References
+
+- [Cobra Context Documentation](https://pkg.go.dev/github.com/spf13/cobra#Command.Context)
+- [Go Context Best Practices](https://go.dev/blog/context)
+- [Effective Go - Package-level Variables](https://go.dev/doc/effective_go#package-names)


### PR DESCRIPTION
## Summary

- Introduces `CommandContext` struct to encapsulate `Config` and `Logger` dependencies
- Replaces deprecated `GetLogger()` and `GetConfig()` with explicit dependency injection via `GetCommandContext()`
- Migrates all subcommands (convert, display, validate) to use the new pattern
- Adds comprehensive tests for context accessor functions

## Changes

| File | Change |
|------|--------|
| `cmd/context.go` | New CommandContext infrastructure with typed context key |
| `cmd/context_test.go` | Comprehensive tests for Get/Set/MustGet functions |
| `cmd/root.go` | Sets CommandContext in PersistentPreRunE, removes deprecated accessors |
| `cmd/convert.go` | Uses CommandContext for logger/config access |
| `cmd/display.go` | Uses CommandContext for logger/config access |
| `cmd/validate.go` | Uses CommandContext for logger/config access |
| `AGENTS.md` | Documents CommandContext pattern (5.7) and context key types (5.8) |

## Test plan

- [x] `just ci-check` passes
- [x] `go test -race ./cmd/...` passes
- [x] All existing cmd tests pass with updated assertions

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)