### PR TITLE
fix(converter): sort map iterations for deterministic report output

### DIFF
--- a/internal/converter/builder/builder.go
+++ b/internal/converter/builder/builder.go
@@ -266,7 +266,9 @@ func (b *MarkdownBuilder) writeNetworkSection(md *markdown.Markdown, data *model
 		netConfig.Interfaces,
 	)
 
-	for name, iface := range netConfig.Interfaces.Items {
+	// Sort interface names for deterministic output
+	for _, name := range slices.Sorted(maps.Keys(netConfig.Interfaces.Items)) {
+		iface := netConfig.Interfaces.Items[name]
 		sectionName := strings.ToUpper(name[:1]) + strings.ToLower(name[1:]) + " Interface"
 		md.H3(sectionName)
 		buildInterfaceDetails(md, iface)
@@ -780,7 +782,9 @@ func BuildInterfaceTableSet(interfaces model.Interfaces) *markdown.TableSet {
 	headers := []string{"Name", "Description", "IP Address", "CIDR", "Enabled"}
 
 	rows := make([][]string, 0, len(interfaces.Items))
-	for name, iface := range interfaces.Items {
+	// Sort interface names for deterministic table rows
+	for _, name := range slices.Sorted(maps.Keys(interfaces.Items)) {
+		iface := interfaces.Items[name]
 		description := iface.Descr
 		if description == "" {
 			description = iface.If

--- a/internal/converter/markdown.go
+++ b/internal/converter/markdown.go
@@ -6,7 +6,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/EvilBit-Labs/opnDossier/internal/converter/formatters"
@@ -210,7 +212,9 @@ func (c *MarkdownConverter) buildNetworkSection(md *markdown.Markdown, opnsense 
 	}
 
 	// Add other interfaces dynamically if they exist
-	for name, iface := range netConfig.Interfaces.Items {
+	// Sort interface names for deterministic output
+	for _, name := range slices.Sorted(maps.Keys(netConfig.Interfaces.Items)) {
+		iface := netConfig.Interfaces.Items[name]
 		if name != "wan" && name != "lan" {
 			// Create consistent section names for other interfaces
 			// Use proper case conversion for interface names


### PR DESCRIPTION
## Summary
- Sort interface map iterations using `slices.Sorted(maps.Keys())` in builder and markdown converter for deterministic output
- Applies to 3 locations: interface sections, interface table, and legacy markdown converter
- Matches existing pattern used for DHCP scopes

## Test Plan
- [x] `just ci-check` passes (lint 0 issues, all tests green)
- [ ] Verify regenerated reports have stable ordering across runs
- [ ] Confirm diffs no longer show spurious interface reordering

Closes #243