### PR TITLE
feat(audit): implement dynamic logging levels for audit mode

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -158,7 +158,8 @@ to your firewall configuration.
     --comprehensive             - Generate detailed, comprehensive reports
 
   AUDIT MODE:
-  Enable security auditing with compliance plugins:
+	Enable security auditing with compliance plugins.
+	Audit logging respects global output flags (--verbose/--quiet):
 
     --audit-mode standard|blue|red  - Enable audit reporting mode
     --audit-plugins stig,sans,firewall - Select compliance plugins to run
@@ -227,6 +228,12 @@ Examples:
 
   # Blue team defensive audit with STIG and SANS compliance
   opnDossier convert config.xml --audit-mode blue --audit-plugins stig,sans
+
+	# Blue team audit with verbose audit diagnostics
+	opnDossier --verbose convert config.xml --audit-mode blue --audit-plugins stig,sans
+
+	# Quiet audit mode (errors only)
+	opnDossier --quiet convert config.xml --audit-mode blue
 
   # Red team attack surface analysis with blackhat commentary
   opnDossier convert config.xml --audit-mode red --audit-blackhat


### PR DESCRIPTION
This pull request introduces improvements to audit mode logging, ensuring audit logs respect the application's global verbosity and quiet flags. The main change is the introduction of a mapping function that synchronizes log levels across different logging libraries used in audit mode. Additionally, the documentation and tests have been updated to reflect and verify this behavior.

Audit mode logging improvements:

* Added the `determineAuditLogLevels` function and `auditLogLevels` struct in `cmd/audit_handler.go` to map the application's logger level to the appropriate levels for both `slog` and `charmlog` used in audit mode components. This ensures audit logging respects global output flags such as `--verbose` and `--quiet`.
* Updated the initialization of audit mode loggers in `handleAuditMode` to use the mapped log levels, replacing hardcoded values. [[1]](diffhunk://#diff-314b82c0b1d211c92a0394a8ee26d17d2a2ece3c9b1d8f57a9f5b6574f1d9065R46-R50) [[2]](diffhunk://#diff-314b82c0b1d211c92a0394a8ee26d17d2a2ece3c9b1d8f57a9f5b6574f1d9065L57-R59)

Testing enhancements:

* Added `TestDetermineAuditLogLevels` in `cmd/audit_handler_test.go` to verify correct mapping of log levels between application logger and audit mode loggers.
* Included necessary imports for logging libraries in `cmd/audit_handler_test.go`.

Documentation updates:

* Clarified audit mode documentation in `cmd/convert.go` to explain that audit logging now respects global output flags.
* Added example commands demonstrating verbose and quiet audit modes in `cmd/convert.go`.