### PR TITLE
refactor(docs): update AGENTS.md and add pkg-internal-import-boundary…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ This document consolidates all development standards, architectural principles, 
 - **[Gotchas](GOTCHAS.md)** - Common pitfalls and non-obvious behaviors
 - **[Tasks](project_spec/tasks.md)** - Implementation tasks (HOW)
 - **[User Stories](project_spec/user_stories.md)** - User stories (WHY)
+- **[Solutions](docs/solutions/)** - Documented problem solutions for searchable future reference
 
 ---
 
@@ -434,9 +435,17 @@ common "github.com/EvilBit-Labs/opnDossier/pkg/model"             // use common.
 
 Files in `pkg/parser/opnsense/` (package `opnsense`) **must** alias the schema import as `schema` to avoid collision. `cmd/` files that use the parser factory import `"github.com/EvilBit-Labs/opnDossier/pkg/parser"` (no alias needed -- package name `parser` is unambiguous).
 
+`parser.NewFactory(decoder)` requires an `XMLDecoder` argument -- wire with `parser.NewFactory(cfgparser.NewXMLParser())` at the call site. The `XMLDecoder` interface is defined in `pkg/parser/factory.go`.
+
 ### 5.24 Public Package Purity
 
 `pkg/` packages must NEVER import `internal/` packages. Any type exposed through a `pkg/` struct field must itself live in `pkg/` or stdlib. When moving types from `internal/` to `pkg/`, audit all struct fields for leaked internal types and define public equivalents in `pkg/` (e.g., `pkg/model.Severity` replaces `internal/analysis.Severity` in `ConversionWarning`).
+
+**Boundary verification:** `grep -rn 'internal/' --include='*.go' pkg/ | grep -v _test.go` -- run before committing `pkg/` changes.
+
+**Interface injection pattern:** When `pkg/` needs `internal/` functionality, define an interface in `pkg/` and inject the concrete implementation at the `cmd/` layer. See `pkg/parser.XMLDecoder` for the canonical example. Go's structural typing allows `pkg/` sub-packages to define their own unexported interface that `internal/` types satisfy without importing them.
+
+**Unexporting types:** When making a type unexported (e.g., `Converter` -> `converter`), add a convenience function (e.g., `ConvertDocument()`) for external test packages that cannot access unexported constructors.
 
 ---
 

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -39,6 +39,99 @@ Built with modern Go practices and established libraries:
 
 The CLI uses a layered architecture: **Cobra** provides command structure and argument parsing, **Viper** handles layered configuration management (files, env, flags), and **Fang** adds enhanced UX features like styled help, automatic version flags, and shell completion.
 
+## Public Package Boundaries and Interface Injection
+
+### The pkg/internal/ Import Boundary
+
+`pkg/` packages must **NEVER** import `internal/` packages. Any type exposed through a `pkg/` struct field must itself live in `pkg/` or stdlib. This enforces a strict architectural boundary that ensures external consumers can use the public API without encountering Go's `internal/` access restrictions.
+
+**Key Principle**: When moving types from `internal/` to `pkg/`, audit all struct fields for leaked internal types and define public equivalents in `pkg/` (e.g., `pkg/model.Severity` replaces `internal/analysis.Severity` in `ConversionWarning`).
+
+### Boundary Verification
+
+Before committing changes to `pkg/` packages, run this command to catch boundary violations:
+
+```bash
+grep -rn 'internal/' --include='*.go' pkg/ | grep -v _test.go
+```
+
+This checks for any production code in `pkg/` that imports `internal/` packages. Test files (`*_test.go`) are allowed to import `internal/` packages since Go's access restrictions only apply to external consumers.
+
+### Interface Injection Pattern
+
+When `pkg/` packages need functionality from `internal/` packages, use **interface injection** instead of moving entire dependency chains:
+
+1. **Define an interface in `pkg/`** with the required methods
+2. **Inject the concrete implementation at the `cmd/` layer** where both `pkg/` and `internal/` packages are accessible
+3. **Use the interface type** in `pkg/` package constructors and fields
+
+#### Canonical Example: XMLDecoder
+
+The `pkg/parser.XMLDecoder` interface demonstrates this pattern:
+
+```go
+// pkg/parser/factory.go
+type XMLDecoder interface {
+    Parse(ctx context.Context, r io.Reader) (*schema.OpnSenseDocument, error)
+    ParseAndValidate(ctx context.Context, r io.Reader) (*schema.OpnSenseDocument, error)
+}
+
+func NewFactory(decoder XMLDecoder) *Factory {
+    return &Factory{xmlDecoder: decoder}
+}
+```
+
+Application code in `cmd/` wires the concrete implementation:
+
+```go
+// cmd/convert.go
+factory := parser.NewFactory(cfgparser.NewXMLParser())
+```
+
+This allows `pkg/parser` to use XML parsing functionality from `internal/cfgparser` without importing it directly.
+
+### Structural Typing for Sub-Packages
+
+Go's structural typing allows `pkg/` sub-packages to define their own **unexported interface** that `internal/` types satisfy without importing them:
+
+```go
+// pkg/parser/opnsense/parser.go
+type xmlDecoder interface {
+    Parse(ctx context.Context, r io.Reader) (*schema.OpnSenseDocument, error)
+    ParseAndValidate(ctx context.Context, r io.Reader) (*schema.OpnSenseDocument, error)
+}
+
+func NewParser(decoder xmlDecoder) *Parser {
+    return &Parser{decoder: decoder}
+}
+```
+
+The `internal/cfgparser.XMLParser` type satisfies this interface through structural compatibility, without requiring an explicit import.
+
+### Unexporting Types Pattern
+
+When making a type unexported (e.g., `Converter` → `converter`) to reduce API surface area, provide a **convenience function** for external test packages that cannot access unexported constructors:
+
+```go
+// pkg/parser/opnsense/converter.go
+type converter struct {
+    // unexported fields
+}
+
+// ConvertDocument provides public access for testing and external consumers
+func ConvertDocument(doc *schema.OpnSenseDocument) (*common.CommonDevice, []common.ConversionWarning, error) {
+    c := &converter{}
+    return c.ToCommonDevice(doc)
+}
+```
+
+This allows external test packages to use the conversion functionality without accessing the unexported `converter` type directly.
+
+### Related Documentation
+
+For detailed examples and the historical context of fixing `pkg/internal/` boundary violations, see:
+- **[docs/solutions/architecture-issues/pkg-internal-import-boundary.md](../solutions/architecture-issues/pkg-internal-import-boundary.md)**
+
 ## Services and Components
 
 ### 1. CLI Interface Layer

--- a/docs/solutions/architecture-issues/pkg-internal-import-boundary.md
+++ b/docs/solutions/architecture-issues/pkg-internal-import-boundary.md
@@ -1,0 +1,83 @@
+---
+title: Fixing pkg/ importing internal/ packages
+category: architecture-issues
+date: 2026-03-16
+tags: [go, public-api, dependency-injection, interface, pkg-boundary]
+components: [pkg/parser, pkg/schema/opnsense]
+related_issues: ['#301']
+---
+
+## Problem
+
+After moving packages from `internal/` to `pkg/` to create a public API (issue #301), four production files in `pkg/` still imported `internal/` packages. Go enforces the `internal/` access boundary at the module level -- any external consumer running `go get` would get a build error:
+
+```text
+use of internal package github.com/EvilBit-Labs/opnDossier/internal/cfgparser not allowed
+```
+
+Affected files:
+
+- `pkg/parser/factory.go` -- imported `internal/cfgparser` for `DefaultMaxInputSize`
+- `pkg/parser/opnsense/parser.go` -- imported `internal/cfgparser` for `NewXMLParser()`
+- `pkg/schema/opnsense/common.go` -- imported `internal/constants` for `NetworkAny`
+- `pkg/schema/opnsense/security.go` -- imported `internal/constants` for `NetworkAny`
+
+## Root Cause
+
+The move from `internal/` to `pkg/` was mechanical (import path updates) but did not address structural dependencies. `cfgparser` depends on `internal/validator` which depends on `internal/constants`, so moving the whole chain would cascade across the codebase.
+
+## Solution
+
+Two separate fixes for the two dependency chains:
+
+### 1. Trivial constant extraction (constants.NetworkAny)
+
+Defined `const NetworkAny = "any"` locally in `pkg/schema/opnsense/constants.go` and removed the `internal/constants` import. The internal package keeps its own copy -- both are independent definitions of the same string literal.
+
+### 2. Interface injection for XML parser (cfgparser.XMLParser)
+
+Instead of moving `cfgparser` to `pkg/` (which would cascade into `validator` and `constants`), defined an `XMLDecoder` interface in `pkg/parser/`:
+
+```go
+// pkg/parser/factory.go
+type XMLDecoder interface {
+    Parse(ctx context.Context, r io.Reader) (*schema.OpnSenseDocument, error)
+    ParseAndValidate(ctx context.Context, r io.Reader) (*schema.OpnSenseDocument, error)
+}
+
+func NewFactory(decoder XMLDecoder) *Factory {
+    return &Factory{xmlDecoder: decoder}
+}
+```
+
+The `Parser` in `pkg/parser/opnsense/` uses a local unexported interface (Go structural typing satisfies it):
+
+```go
+// pkg/parser/opnsense/parser.go
+type xmlDecoder interface {
+    Parse(ctx context.Context, r io.Reader) (*schema.OpnSenseDocument, error)
+    ParseAndValidate(ctx context.Context, r io.Reader) (*schema.OpnSenseDocument, error)
+}
+
+func NewParser(decoder xmlDecoder) *Parser {
+    return &Parser{decoder: decoder}
+}
+```
+
+Application code wires the concrete implementation:
+
+```go
+// cmd/convert.go (and other cmd/ files)
+factory := parser.NewFactory(cfgparser.NewXMLParser())
+```
+
+### 3. Unexport Converter (bonus API surface reduction)
+
+Renamed `Converter` to `converter` (unexported) since `Parser` is the intended entry point. Added `ConvertDocument()` as a convenience function for consumers who have a pre-parsed `OpnSenseDocument`.
+
+## Prevention
+
+- Before exposing `internal/` packages as `pkg/`, run: `grep -rn 'internal/' --include='*.go' pkg/ | grep -v _test.go` to catch boundary violations.
+- Consider adding a CI check or linter rule that flags `internal/` imports from `pkg/` production code.
+- When a `pkg/` package needs functionality from `internal/`, prefer interface injection over moving entire dependency chains.
+- Test files in `pkg/` *can* import `internal/` (Go allows this) -- only production code is restricted for external consumers.


### PR DESCRIPTION
This pull request improves documentation and architectural standards related to Go package boundaries, specifically addressing issues where `pkg/` packages improperly imported `internal/` packages. It introduces guidance on interface injection, boundary verification, and unexporting types, and adds a new solutions document detailing the fixes applied to resolve these violations.

Documentation and standards updates:

* Added a new entry in `AGENTS.md` linking to documented solutions for architectural issues, making problem resolutions more discoverable.
* Expanded the architectural standards section in `AGENTS.md` with detailed guidance on interface injection, boundary verification, and handling unexported types, including canonical examples and command-line checks for boundary violations.

Problem solution documentation:

* Added `docs/solutions/architecture-issues/pkg-internal-import-boundary.md`, which explains the root cause of `pkg/` importing `internal/`, the fixes applied (constant extraction, interface injection, API surface reduction), and prevention strategies for future violations.