### PR TITLE
docs: address CodeRabbit feedback from PR #550

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -281,7 +281,13 @@ This refactoring was completed in PR #431 (closing issue #323) and maintains ful
 ##### Unit Tests for Methods
 
 ```go
-// import "github.com/EvilBit-Labs/opnDossier/internal/converter/builder"
+import (
+    "testing"
+
+    "github.com/EvilBit-Labs/opnDossier/internal/converter/builder"
+    "github.com/EvilBit-Labs/opnDossier/internal/model/common"
+    "github.com/stretchr/testify/assert"
+)
 
 func TestMarkdownBuilder_FilterSystemTunables(t *testing.T) {
     tests := []struct {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -284,9 +284,10 @@ This refactoring was completed in PR #431 (closing issue #323) and maintains ful
 import (
     "testing"
 
-    "github.com/EvilBit-Labs/opnDossier/internal/converter/builder"
-    "github.com/EvilBit-Labs/opnDossier/internal/model/common"
     "github.com/stretchr/testify/assert"
+
+    "github.com/EvilBit-Labs/opnDossier/internal/converter/builder"
+    common "github.com/EvilBit-Labs/opnDossier/pkg/model"
 )
 
 func TestMarkdownBuilder_FilterSystemTunables(t *testing.T) {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,6 +102,9 @@ output_file: ''
 # Enable verbose logging (debug level)
 verbose: false
 
+# Enable debug mode (all messages, for troubleshooting; mutually exclusive with verbose/quiet)
+debug: false
+
 # Enable quiet mode (suppress all except errors)
 quiet: false
 
@@ -202,6 +205,7 @@ All environment variables use the `OPNDOSSIER_` prefix with the following transf
 | `input_file`                   | `OPNDOSSIER_INPUT_FILE`                   | string   | ""         |
 | `output_file`                  | `OPNDOSSIER_OUTPUT_FILE`                  | string   | ""         |
 | `verbose`                      | `OPNDOSSIER_VERBOSE`                      | boolean  | false      |
+| `debug`                        | `OPNDOSSIER_DEBUG`                        | boolean  | false      |
 | `quiet`                        | `OPNDOSSIER_QUIET`                        | boolean  | false      |
 | `format`                       | `OPNDOSSIER_FORMAT`                       | string   | "markdown" |
 | `theme`                        | `OPNDOSSIER_THEME`                        | string   | ""         |
@@ -269,12 +273,12 @@ These flags are available on all commands:
 opnDossier convert [flags] [file ...]
 ```
 
-| Flag         | Short | Description                                      | Default    |
-| ------------ | ----- | ------------------------------------------------ | ---------- |
-| `--output`   | `-o`  | Output file path (default: stdout)               | ""         |
-| `--format`   | `-f`  | Output format (markdown, json, yaml, text, html) | "markdown" |
-| `--sections` |       | Sections to include (comma-separated)            | all        |
-| `--force`    |       | Overwrite existing output file                   | false      |
+| Flag        | Short | Description                                      | Default    |
+| ----------- | ----- | ------------------------------------------------ | ---------- |
+| `--output`  | `-o`  | Output file path (default: stdout)               | ""         |
+| `--format`  | `-f`  | Output format (markdown, json, yaml, text, html) | "markdown" |
+| `--section` |       | Sections to include (comma-separated)            | all        |
+| `--force`   |       | Overwrite existing output file                   | false      |
 
 #### display
 
@@ -308,6 +312,7 @@ opnDossier validate [flags] <config.xml>
 | `input_file`  | string   | ""         | Any valid file path             | Default input file path           |
 | `output_file` | string   | ""         | Any valid file path             | Default output file path          |
 | `verbose`     | boolean  | false      | true, false                     | Enable debug-level logging        |
+| `debug`       | boolean  | false      | true, false                     | Enable debug mode (troubleshoot)  |
 | `quiet`       | boolean  | false      | true, false                     | Suppress non-error output         |
 | `format`      | string   | "markdown" | markdown, md, json, yaml, yml   | Output format                     |
 | `theme`       | string   | ""         | light, dark, auto, none, custom | Terminal display theme            |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -99,10 +99,12 @@ input_file: ''
 # Default output file path (empty = stdout)
 output_file: ''
 
-# Enable verbose logging (debug level)
+# Enable verbose logging (info level: warnings, errors, informational messages)
 verbose: false
 
-# Enable debug mode (all messages, for troubleshooting; mutually exclusive with verbose/quiet)
+# Enable debug logging (all messages, for troubleshooting)
+# CLI flags --verbose/--debug/--quiet are mutually exclusive.
+# In config/env, if multiple are set, precedence is: quiet > debug > verbose.
 debug: false
 
 # Enable quiet mode (suppress all except errors)
@@ -262,8 +264,11 @@ These flags are available on all commands:
 | Flag        | Short | Description                                           |
 | ----------- | ----- | ----------------------------------------------------- |
 | `--config`  |       | Configuration file path (default: ~/.opnDossier.yaml) |
-| `--verbose` | `-v`  | Enable verbose/debug output                           |
+| `--verbose` | `-v`  | Enable verbose (info-level) logging                   |
+| `--debug`   |       | Enable debug-level logging (all messages)             |
 | `--quiet`   | `-q`  | Suppress all output except errors                     |
+
+`--verbose`, `--debug`, and `--quiet` are mutually exclusive at the CLI. In the config file or environment variables, if more than one is set, precedence is `quiet > debug > verbose`.
 
 ### Command-Specific Flags
 
@@ -311,7 +316,7 @@ opnDossier validate [flags] <config.xml>
 | ------------- | -------- | ---------- | ------------------------------- | --------------------------------- |
 | `input_file`  | string   | ""         | Any valid file path             | Default input file path           |
 | `output_file` | string   | ""         | Any valid file path             | Default output file path          |
-| `verbose`     | boolean  | false      | true, false                     | Enable debug-level logging        |
+| `verbose`     | boolean  | false      | true, false                     | Enable info-level logging         |
 | `debug`       | boolean  | false      | true, false                     | Enable debug mode (troubleshoot)  |
 | `quiet`       | boolean  | false      | true, false                     | Suppress non-error output         |
 | `format`      | string   | "markdown" | markdown, md, json, yaml, yml   | Output format                     |

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -44,10 +44,11 @@ sections: []
 
 ### Configuration Options
 
-| Option        | Type     | Default      | Description                                                              |
-| ------------- | -------- | ------------ | ------------------------------------------------------------------------ |
-| `verbose`     | boolean  | `false`      | Enable info-level logging (warnings, errors, and informational messages) |
-| `quiet`       | boolean  | `false`      | Suppress all output except errors                                        |
+| Option        | Type     | Default      | Description                                                                                         |
+| ------------- | -------- | ------------ | --------------------------------------------------------------------------------------------------- |
+| `verbose`     | boolean  | `false`      | Enable info-level logging (warnings, errors, and informational messages)                            |
+| `debug`       | boolean  | `false`      | Enable debug mode - shows all messages for troubleshooting (mutually exclusive with verbose/quiet)  |
+| `quiet`       | boolean  | `false`      | Suppress all output except errors                                                                   |
 | `format`      | string   | `"markdown"` | Output format (markdown, json, yaml, text, html)                         |
 | `theme`       | string   | `""`         | Display theme (auto, dark, light, none)                                  |
 | `wrap`        | int      | `-1`         | Text wrap width (-1=auto, 0=off, >0=columns)                             |
@@ -65,6 +66,7 @@ All configuration options can be set using environment variables with the `OPNDO
 ```bash
 # Logging configuration
 export OPNDOSSIER_VERBOSE=true
+export OPNDOSSIER_DEBUG=false
 export OPNDOSSIER_QUIET=false
 
 # Output settings

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -44,11 +44,11 @@ sections: []
 
 ### Configuration Options
 
-| Option        | Type     | Default      | Description                                                                                         |
-| ------------- | -------- | ------------ | --------------------------------------------------------------------------------------------------- |
-| `verbose`     | boolean  | `false`      | Enable info-level logging (warnings, errors, and informational messages)                            |
-| `debug`       | boolean  | `false`      | Enable debug mode - shows all messages for troubleshooting (mutually exclusive with verbose/quiet)  |
-| `quiet`       | boolean  | `false`      | Suppress all output except errors                                                                   |
+| Option        | Type     | Default      | Description                                                              |
+| ------------- | -------- | ------------ | ------------------------------------------------------------------------ |
+| `verbose`     | boolean  | `false`      | Enable info-level logging (warnings, errors, and informational messages) |
+| `debug`       | boolean  | `false`      | Enable debug-level logging (all messages, for troubleshooting)           |
+| `quiet`       | boolean  | `false`      | Suppress all output except errors                                        |
 | `format`      | string   | `"markdown"` | Output format (markdown, json, yaml, text, html)                         |
 | `theme`       | string   | `""`         | Display theme (auto, dark, light, none)                                  |
 | `wrap`        | int      | `-1`         | Text wrap width (-1=auto, 0=off, >0=columns)                             |
@@ -91,7 +91,7 @@ Environment variables follow this pattern:
 
 ## Command-Line Flags
 
-Command-line flags have the highest precedence and override both environment variables and config file values. Global flags (like `--verbose` and `--quiet`) apply to all commands, while some flags are command-specific (like `--theme` for `display` or `--mode` for `audit`).
+Command-line flags have the highest precedence and override both environment variables and config file values. Global flags (like `--verbose`, `--debug`, and `--quiet`) apply to all commands, while some flags are command-specific (like `--theme` for `display` or `--mode` for `audit`). `--verbose`, `--debug`, and `--quiet` are mutually exclusive at the CLI; when set via config or environment variables, the resolution precedence is `quiet > debug > verbose`.
 
 Each command's flags are documented on its own page under [Commands](commands/overview.md). For a single table listing every flag, environment variable, and config file key, see the [Configuration Reference](configuration-reference.md).
 


### PR DESCRIPTION
## Summary

Follow-up to PR #550 addressing 3 unresolved CodeRabbit review threads that landed after the PR merged. Pure documentation — no runtime behavior change.

**Impact:** 3 files, +24/-11 lines · **Risk:** 🟢 Low · **Review time:** ~3 minutes

## What Changed

### 📝 Documentation

- **M** `CONTRIBUTING.md` — In the builder unit-test code example, replaced a single commented placeholder import line with a real `import (...)` block (`testing`, `builder`, `common`, `testify/assert`) so the snippet is copy/paste runnable.
- **M** `docs/configuration.md` — Added the `debug` config key to three places it was missing from: the YAML reference block, the env-var table (`OPNDOSSIER_DEBUG`), and the basic settings table.
- **M** `docs/configuration.md` — Fixed `--sections` → `--section` in the `convert` flag table to match the actual CLI flag.
- **M** `docs/user-guide/configuration.md` — Dosu-bot auto-sync mirroring the above corrections to the MkDocs user-guide copy.

## Why These Changes

| Thread | Reviewer concern | Evidence this is real |
|---|---|---|
| [#550 r3070976086](https://github.com/EvilBit-Labs/opnDossier/pull/550#discussion_r3070976086) | Copy/paste-broken import example | Placeholder was commented out; snippet called `builder.NewMarkdownBuilder()` with no resolvable import |
| #550 thread `PRRT_...56bzAh` | `debug` undocumented | `internal/config/config.go:46` (field), `:98` (default), `cmd/root.go:201` (flag) — exists but invisible to users |
| #550 thread `PRRT_...56bzAj` | Docs say `--sections`; CLI says `--section` | `cmd/convert.go:100` registers `section` (singular); example at `:181` uses `--section` |

## Type of Change

- [x] 📝 Documentation update
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change

## How This Has Been Tested

- [x] `pre-commit run --files CONTRIBUTING.md docs/configuration.md` — passes (mdformat clean)
- [x] Verified `debug` field exists via `grep -rn '\"debug\"\|OPNDOSSIER_DEBUG' internal/config/ cmd/`
- [x] Verified `--section` (singular) is the registered flag via `grep -rn 'section' cmd/convert.go cmd/display.go`
- [x] No code changes — no unit/integration tests affected

## Breaking Changes

None. Documentation-only.

## Review Checklist

### Documentation
- [x] Documentation matches current CLI behavior
- [x] Examples are copy/paste runnable
- [x] No divergence between three `debug` reference sites
- [x] Cross-references (YAML ref, env-var table, basic settings) stay in sync
- [x] User-guide copy (`docs/user-guide/configuration.md`) stays in sync via Dosu

### Process
- [x] DCO sign-off present (`-s` flag)
- [x] Conventional commit format (`docs:`)
- [x] Source threads on #550 resolved (already replied + resolved via GraphQL)

## Related

- Parent PR: #550 (merged, template system removal)
- CodeRabbit threads: 3 resolved on #550 linking back to this follow-up