### PR TITLE
perf(NATS-7): replace O(n²) duplicate rule detection with hash buckets

### DIFF
--- a/cmd/config_validate.go
+++ b/cmd/config_validate.go
@@ -286,21 +286,21 @@ func showLineContextPlain(content []byte, lineNum int) {
 // findUnknownKeys checks for unknown configuration keys.
 func findUnknownKeys(raw map[string]any) []string {
 	knownKeys := map[string]bool{
-		"input_file":   true,
-		"output_file":  true,
-		"verbose":      true,
-		"quiet":        true,
-		"theme":        true,
-		"format":       true,
-		"sections":     true,
-		"wrap":         true,
-		"json_output":  true,
-		"minimal":      true,
-		"no_progress":  true,
-		"display":      true,
-		"export":       true,
-		"logging":      true,
-		"validation":   true,
+		"input_file":  true,
+		"output_file": true,
+		"verbose":     true,
+		"quiet":       true,
+		"theme":       true,
+		"format":      true,
+		"sections":    true,
+		"wrap":        true,
+		"json_output": true,
+		"minimal":     true,
+		"no_progress": true,
+		"display":     true,
+		"export":      true,
+		"logging":     true,
+		"validation":  true,
 	}
 
 	knownNestedKeys := map[string]map[string]bool{

--- a/internal/analysis/detect.go
+++ b/internal/analysis/detect.go
@@ -49,6 +49,16 @@ func DetectDeadRules(cfg *common.CommonDevice) []common.DeadRuleFinding {
 
 	for _, iface := range slices.Sorted(maps.Keys(interfaceRules)) {
 		rules := interfaceRules[iface]
+
+		// Bucket prior rules by hash so duplicate detection runs in O(n) on the
+		// common case (distinct rules hit empty buckets). Worst case remains
+		// O(n²) when every rule is equivalent — expected and acceptable, since
+		// that workload requires the pairwise findings anyway. Findings are
+		// emitted when the later duplicate is visited; RuleIndex points to the
+		// duplicate and the description references the earlier rule, matching
+		// the prior nested-loop output byte-for-byte.
+		buckets := make(map[uint64][]int, len(rules))
+
 		for i, ir := range rules {
 			// Block-all makes subsequent rules unreachable.
 			srcAny := ir.Rule.Source.Address == constants.NetworkAny
@@ -66,21 +76,23 @@ func DetectDeadRules(cfg *common.CommonDevice) []common.DeadRuleFinding {
 				})
 			}
 
-			// Duplicate detection.
-			for j := i + 1; j < len(rules); j++ {
-				if RulesEquivalent(ir.Rule, rules[j].Rule) {
+			// Duplicate detection via hash bucket.
+			h := hashRule(ir.Rule)
+			for _, priorIdx := range buckets[h] {
+				if RulesEquivalent(rules[priorIdx].Rule, ir.Rule) {
 					findings = append(findings, common.DeadRuleFinding{
 						Kind:      common.DeadRuleKindDuplicate,
-						RuleIndex: rules[j].Index,
+						RuleIndex: ir.Index,
 						Interface: iface,
 						Description: fmt.Sprintf(
 							"Rule at position %d is duplicate of rule at position %d on interface %s",
-							rules[j].Index+1, ir.Index+1, iface,
+							ir.Index+1, rules[priorIdx].Index+1, iface,
 						),
 						Recommendation: "Remove duplicate rule to simplify configuration",
 					})
 				}
 			}
+			buckets[h] = append(buckets[h], i)
 		}
 	}
 

--- a/internal/analysis/detect.go
+++ b/internal/analysis/detect.go
@@ -51,12 +51,15 @@ func DetectDeadRules(cfg *common.CommonDevice) []common.DeadRuleFinding {
 		rules := interfaceRules[iface]
 
 		// Bucket prior rules by hash so duplicate detection runs in O(n) on the
-		// common case (distinct rules hit empty buckets). Worst case remains
-		// O(n²) when every rule is equivalent — expected and acceptable, since
-		// that workload requires the pairwise findings anyway. Findings are
-		// emitted when the later duplicate is visited; RuleIndex points to the
-		// duplicate and the description references the earlier rule, matching
-		// the prior nested-loop output byte-for-byte.
+		// common case (distinct rules hit empty buckets). Worst case is O(n²)
+		// when every rule is equivalent — required anyway because each pair
+		// yields a finding. Findings are buffered under the "owner" rule's
+		// per-interface position (block-all owns its unreachable finding; the
+		// earlier rule owns each duplicate finding) and flattened in position
+		// order so output matches the prior nested-loop implementation
+		// byte-for-byte, even for equivalence classes of size ≥ 4 and for
+		// block-all rules interleaved with duplicates.
+		perPos := make([][]common.DeadRuleFinding, len(rules))
 		buckets := make(map[uint64][]int, len(rules))
 
 		for i, ir := range rules {
@@ -64,7 +67,7 @@ func DetectDeadRules(cfg *common.CommonDevice) []common.DeadRuleFinding {
 			srcAny := ir.Rule.Source.Address == constants.NetworkAny
 			dstAny := ir.Rule.Destination.Address == constants.NetworkAny
 			if ir.Rule.Type == common.RuleTypeBlock && srcAny && dstAny && i < len(rules)-1 {
-				findings = append(findings, common.DeadRuleFinding{
+				perPos[i] = append(perPos[i], common.DeadRuleFinding{
 					Kind:      common.DeadRuleKindUnreachable,
 					RuleIndex: ir.Index,
 					Interface: iface,
@@ -76,11 +79,13 @@ func DetectDeadRules(cfg *common.CommonDevice) []common.DeadRuleFinding {
 				})
 			}
 
-			// Duplicate detection via hash bucket.
+			// Duplicate detection via hash bucket. Each duplicate is recorded
+			// under the earlier rule's position so that flattening in position
+			// order reproduces the nested-loop's "group by outer i" ordering.
 			h := hashRule(ir.Rule)
 			for _, priorIdx := range buckets[h] {
 				if RulesEquivalent(rules[priorIdx].Rule, ir.Rule) {
-					findings = append(findings, common.DeadRuleFinding{
+					perPos[priorIdx] = append(perPos[priorIdx], common.DeadRuleFinding{
 						Kind:      common.DeadRuleKindDuplicate,
 						RuleIndex: ir.Index,
 						Interface: iface,
@@ -93,6 +98,10 @@ func DetectDeadRules(cfg *common.CommonDevice) []common.DeadRuleFinding {
 				}
 			}
 			buckets[h] = append(buckets[h], i)
+		}
+
+		for _, bucketFindings := range perPos {
+			findings = append(findings, bucketFindings...)
 		}
 	}
 

--- a/internal/analysis/detect_bench_test.go
+++ b/internal/analysis/detect_bench_test.go
@@ -1,0 +1,59 @@
+package analysis_test
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/EvilBit-Labs/opnDossier/internal/analysis"
+	common "github.com/EvilBit-Labs/opnDossier/pkg/model"
+)
+
+// buildRuleSet produces n distinct firewall rules on a single interface to
+// exercise the duplicate-detection hot path in DetectDeadRules. Rules are
+// intentionally unique so every rule hits a fresh hash bucket — this is the
+// common-case workload the hash-based algorithm optimizes for.
+func buildRuleSet(n int) *common.CommonDevice {
+	rules := make([]common.FirewallRule, n)
+	for i := range n {
+		rules[i] = common.FirewallRule{
+			Type:        common.RuleTypePass,
+			IPProtocol:  common.IPProtocolInet,
+			Interfaces:  []string{"lan"},
+			StateType:   "keep state",
+			Direction:   common.DirectionIn,
+			Protocol:    "tcp",
+			Quick:       true,
+			Source:      common.RuleEndpoint{Address: fmt.Sprintf("10.%d.%d.0/24", i/256, i%256)},
+			Destination: common.RuleEndpoint{Address: "any", Port: strconv.Itoa(1024 + i)},
+		}
+	}
+	return &common.CommonDevice{FirewallRules: rules}
+}
+
+func BenchmarkDetectDeadRules_100Rules(b *testing.B) {
+	cfg := buildRuleSet(100)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_ = analysis.DetectDeadRules(cfg)
+	}
+}
+
+func BenchmarkDetectDeadRules_500Rules(b *testing.B) {
+	cfg := buildRuleSet(500)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_ = analysis.DetectDeadRules(cfg)
+	}
+}
+
+func BenchmarkDetectDeadRules_1000Rules(b *testing.B) {
+	cfg := buildRuleSet(1000)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_ = analysis.DetectDeadRules(cfg)
+	}
+}

--- a/internal/analysis/detect_test.go
+++ b/internal/analysis/detect_test.go
@@ -191,6 +191,125 @@ func TestDetectDeadRules(t *testing.T) {
 	}
 }
 
+// TestDetectDeadRules_DisabledNotEquivalent ensures a disabled rule is not
+// reported as a duplicate of an otherwise-identical enabled rule. Both
+// RulesEquivalent and hashRule must agree on this — if either drops the
+// Disabled check, integration output changes silently.
+func TestDetectDeadRules_DisabledNotEquivalent(t *testing.T) {
+	t.Parallel()
+
+	rule := common.FirewallRule{
+		Type:        common.RuleTypePass,
+		IPProtocol:  common.IPProtocolInet,
+		Interfaces:  []string{"lan"},
+		Source:      common.RuleEndpoint{Address: "192.168.1.0/24"},
+		Destination: common.RuleEndpoint{Address: "any"},
+	}
+	disabled := rule
+	disabled.Disabled = true
+
+	cfg := &common.CommonDevice{FirewallRules: []common.FirewallRule{rule, disabled}}
+	findings := analysis.DetectDeadRules(cfg)
+	assert.Empty(t, findings, "disabled rule must not duplicate enabled rule")
+}
+
+// TestDetectDeadRules_CrossInterfaceDuplicates ensures that two identical
+// multi-interface rules produce one duplicate finding per shared interface.
+// Guards the per-interface bucket reset — if buckets ever leak across
+// interfaces, counts change.
+func TestDetectDeadRules_CrossInterfaceDuplicates(t *testing.T) {
+	t.Parallel()
+
+	rule := common.FirewallRule{
+		Type:        common.RuleTypePass,
+		IPProtocol:  common.IPProtocolInet,
+		Interfaces:  []string{"wan", "lan"},
+		Source:      common.RuleEndpoint{Address: "192.168.1.0/24"},
+		Destination: common.RuleEndpoint{Address: "any"},
+	}
+	cfg := &common.CommonDevice{FirewallRules: []common.FirewallRule{rule, rule}}
+
+	findings := analysis.DetectDeadRules(cfg)
+	require.Len(t, findings, 2)
+
+	seenIfaces := map[string]bool{}
+	for _, f := range findings {
+		assert.Equal(t, common.DeadRuleKindDuplicate, f.Kind)
+		assert.Equal(t, 1, f.RuleIndex)
+		seenIfaces[f.Interface] = true
+	}
+	assert.True(t, seenIfaces["lan"], "expected duplicate finding on lan")
+	assert.True(t, seenIfaces["wan"], "expected duplicate finding on wan")
+}
+
+// TestDetectDeadRules_BlockAllPlusDuplicate exercises the mixed case: a
+// block-all rule followed by two identical pass rules on one interface.
+// Expected: one unreachable finding (block-all at index 0) plus one duplicate
+// finding (index 2 duplicates index 1).
+func TestDetectDeadRules_BlockAllPlusDuplicate(t *testing.T) {
+	t.Parallel()
+
+	blockAll := common.FirewallRule{
+		Type:        common.RuleTypeBlock,
+		Interfaces:  []string{"wan"},
+		Source:      common.RuleEndpoint{Address: "any"},
+		Destination: common.RuleEndpoint{Address: "any"},
+	}
+	pass := common.FirewallRule{
+		Type:        common.RuleTypePass,
+		IPProtocol:  common.IPProtocolInet,
+		Interfaces:  []string{"wan"},
+		Source:      common.RuleEndpoint{Address: "192.168.1.0/24"},
+		Destination: common.RuleEndpoint{Address: "any"},
+	}
+	cfg := &common.CommonDevice{FirewallRules: []common.FirewallRule{blockAll, pass, pass}}
+
+	findings := analysis.DetectDeadRules(cfg)
+	require.Len(t, findings, 2)
+
+	assert.Equal(t, common.DeadRuleKindUnreachable, findings[0].Kind)
+	assert.Equal(t, 0, findings[0].RuleIndex)
+
+	assert.Equal(t, common.DeadRuleKindDuplicate, findings[1].Kind)
+	assert.Equal(t, 2, findings[1].RuleIndex)
+	assert.Contains(t, findings[1].Description, "position 3 is duplicate of rule at position 2")
+}
+
+// TestDetectDeadRules_TriplicatePairwise verifies the exact pairwise emission
+// contract for three equivalent rules. This is tighter than the existing
+// table-based "wantCount: 3" assertion and would catch a regression to a
+// first-seen-only scheme (which would drop the rule-3-dup-of-rule-2 finding).
+func TestDetectDeadRules_TriplicatePairwise(t *testing.T) {
+	t.Parallel()
+
+	rule := common.FirewallRule{
+		Type:        common.RuleTypePass,
+		IPProtocol:  common.IPProtocolInet,
+		Interfaces:  []string{"lan"},
+		Source:      common.RuleEndpoint{Address: "192.168.1.0/24"},
+		Destination: common.RuleEndpoint{Address: "any"},
+	}
+	cfg := &common.CommonDevice{FirewallRules: []common.FirewallRule{rule, rule, rule}}
+
+	findings := analysis.DetectDeadRules(cfg)
+	require.Len(t, findings, 3)
+
+	type pair struct {
+		dupIndex    int
+		description string
+	}
+	want := []pair{
+		{dupIndex: 1, description: "position 2 is duplicate of rule at position 1"},
+		{dupIndex: 2, description: "position 3 is duplicate of rule at position 1"},
+		{dupIndex: 2, description: "position 3 is duplicate of rule at position 2"},
+	}
+	for i, w := range want {
+		assert.Equal(t, common.DeadRuleKindDuplicate, findings[i].Kind, "finding %d kind", i)
+		assert.Equal(t, w.dupIndex, findings[i].RuleIndex, "finding %d rule index", i)
+		assert.Contains(t, findings[i].Description, w.description, "finding %d description", i)
+	}
+}
+
 func TestDetectUnusedInterfaces(t *testing.T) {
 	t.Parallel()
 

--- a/internal/analysis/detect_test.go
+++ b/internal/analysis/detect_test.go
@@ -310,6 +310,78 @@ func TestDetectDeadRules_TriplicatePairwise(t *testing.T) {
 	}
 }
 
+// TestDetectDeadRules_QuadruplicatePairwise locks in the nested-loop ordering
+// for equivalence classes of size 4. The old algorithm emits findings grouped
+// by the earlier rule's position (i=0 first, then i=1, i=2); a naive hash
+// approach that emits when the later rule is visited would interleave
+// differently. Reported by Copilot on PR #554.
+func TestDetectDeadRules_QuadruplicatePairwise(t *testing.T) {
+	t.Parallel()
+
+	rule := common.FirewallRule{
+		Type:        common.RuleTypePass,
+		IPProtocol:  common.IPProtocolInet,
+		Interfaces:  []string{"lan"},
+		Source:      common.RuleEndpoint{Address: "192.168.1.0/24"},
+		Destination: common.RuleEndpoint{Address: "any"},
+	}
+	cfg := &common.CommonDevice{FirewallRules: []common.FirewallRule{rule, rule, rule, rule}}
+
+	findings := analysis.DetectDeadRules(cfg)
+	require.Len(t, findings, 6)
+
+	type pair struct {
+		dupIndex    int
+		description string
+	}
+	want := []pair{
+		{dupIndex: 1, description: "position 2 is duplicate of rule at position 1"},
+		{dupIndex: 2, description: "position 3 is duplicate of rule at position 1"},
+		{dupIndex: 3, description: "position 4 is duplicate of rule at position 1"},
+		{dupIndex: 2, description: "position 3 is duplicate of rule at position 2"},
+		{dupIndex: 3, description: "position 4 is duplicate of rule at position 2"},
+		{dupIndex: 3, description: "position 4 is duplicate of rule at position 3"},
+	}
+	for i, w := range want {
+		assert.Equal(t, common.DeadRuleKindDuplicate, findings[i].Kind, "finding %d kind", i)
+		assert.Equal(t, w.dupIndex, findings[i].RuleIndex, "finding %d rule index", i)
+		assert.Contains(t, findings[i].Description, w.description, "finding %d description", i)
+	}
+}
+
+// TestDetectDeadRules_DuplicateBeforeBlockAll ensures that when a block-all
+// rule is sandwiched between identical pass rules, the duplicate finding from
+// the earlier pass rule precedes the unreachable finding from the block-all
+// rule — preserving the per-position ordering of the original nested loop.
+func TestDetectDeadRules_DuplicateBeforeBlockAll(t *testing.T) {
+	t.Parallel()
+
+	pass := common.FirewallRule{
+		Type:        common.RuleTypePass,
+		IPProtocol:  common.IPProtocolInet,
+		Interfaces:  []string{"wan"},
+		Source:      common.RuleEndpoint{Address: "192.168.1.0/24"},
+		Destination: common.RuleEndpoint{Address: "any"},
+	}
+	blockAll := common.FirewallRule{
+		Type:        common.RuleTypeBlock,
+		Interfaces:  []string{"wan"},
+		Source:      common.RuleEndpoint{Address: "any"},
+		Destination: common.RuleEndpoint{Address: "any"},
+	}
+	cfg := &common.CommonDevice{FirewallRules: []common.FirewallRule{pass, blockAll, pass}}
+
+	findings := analysis.DetectDeadRules(cfg)
+	require.Len(t, findings, 2)
+
+	assert.Equal(t, common.DeadRuleKindDuplicate, findings[0].Kind)
+	assert.Equal(t, 2, findings[0].RuleIndex)
+	assert.Contains(t, findings[0].Description, "position 3 is duplicate of rule at position 1")
+
+	assert.Equal(t, common.DeadRuleKindUnreachable, findings[1].Kind)
+	assert.Equal(t, 1, findings[1].RuleIndex)
+}
+
 func TestDetectUnusedInterfaces(t *testing.T) {
 	t.Parallel()
 

--- a/internal/analysis/rules.go
+++ b/internal/analysis/rules.go
@@ -1,7 +1,9 @@
 package analysis
 
 import (
+	"hash/fnv"
 	"slices"
+	"strconv"
 
 	common "github.com/EvilBit-Labs/opnDossier/pkg/model"
 )
@@ -43,4 +45,48 @@ func RulesEquivalent(a, b common.FirewallRule) bool {
 	return a.Destination.Address == b.Destination.Address &&
 		a.Destination.Port == b.Destination.Port &&
 		a.Destination.Negated == b.Destination.Negated
+}
+
+// hashRule computes an FNV-64a hash over the same fields that RulesEquivalent
+// compares. Rules for which RulesEquivalent returns true must produce the same
+// hash; the converse need not hold (collisions are tolerated and resolved by
+// callers via a RulesEquivalent fallback). Interface order is normalized so
+// ["wan","lan"] and ["lan","wan"] hash identically.
+//
+// MAINTENANCE INVARIANT: if RulesEquivalent is extended with a new field,
+// hashRule MUST hash that field — otherwise duplicate detection silently
+// misses the new field and produces false negatives.
+func hashRule(r common.FirewallRule) uint64 {
+	h := fnv.New64a()
+
+	writeField := func(s string) {
+		_, _ = h.Write([]byte(s))
+		_, _ = h.Write([]byte{0})
+	}
+
+	writeField(strconv.FormatBool(r.Disabled))
+	writeField(string(r.Type))
+	writeField(string(r.IPProtocol))
+
+	ifaces := slices.Clone(r.Interfaces)
+	slices.Sort(ifaces)
+	for _, iface := range ifaces {
+		writeField(iface)
+	}
+	writeField("")
+
+	writeField(r.StateType)
+	writeField(string(r.Direction))
+	writeField(r.Protocol)
+	writeField(strconv.FormatBool(r.Quick))
+
+	writeField(r.Source.Address)
+	writeField(r.Source.Port)
+	writeField(strconv.FormatBool(r.Source.Negated))
+
+	writeField(r.Destination.Address)
+	writeField(r.Destination.Port)
+	writeField(strconv.FormatBool(r.Destination.Negated))
+
+	return h.Sum64()
 }

--- a/internal/analysis/rules_internal_test.go
+++ b/internal/analysis/rules_internal_test.go
@@ -1,0 +1,91 @@
+package analysis
+
+import (
+	"testing"
+
+	common "github.com/EvilBit-Labs/opnDossier/pkg/model"
+)
+
+func baseHashRule() common.FirewallRule {
+	return common.FirewallRule{
+		Type:       common.RuleTypePass,
+		IPProtocol: common.IPProtocolInet,
+		Interfaces: []string{"wan", "lan"},
+		StateType:  "keep state",
+		Direction:  common.DirectionIn,
+		Protocol:   "tcp",
+		Quick:      true,
+		Source: common.RuleEndpoint{
+			Address: "192.168.1.0/24",
+			Port:    "443",
+		},
+		Destination: common.RuleEndpoint{
+			Address: "10.0.0.0/8",
+			Port:    "80",
+		},
+	}
+}
+
+func TestHashRule_EquivalentRulesHashSame(t *testing.T) {
+	t.Parallel()
+
+	a := baseHashRule()
+	b := baseHashRule()
+	b.Interfaces = []string{"lan", "wan"} // reversed order — RulesEquivalent ignores order
+
+	if !RulesEquivalent(a, b) {
+		t.Fatalf("precondition failed: rules should be equivalent")
+	}
+	if hashRule(a) != hashRule(b) {
+		t.Errorf("equivalent rules produced different hashes: %d vs %d", hashRule(a), hashRule(b))
+	}
+}
+
+func TestHashRule_DistinctRulesHashDifferently(t *testing.T) {
+	t.Parallel()
+
+	base := baseHashRule()
+	h0 := hashRule(base)
+
+	mutations := map[string]func(r *common.FirewallRule){
+		"Disabled":            func(r *common.FirewallRule) { r.Disabled = true },
+		"Type":                func(r *common.FirewallRule) { r.Type = common.RuleTypeBlock },
+		"IPProtocol":          func(r *common.FirewallRule) { r.IPProtocol = common.IPProtocolInet6 },
+		"Interfaces":          func(r *common.FirewallRule) { r.Interfaces = []string{"opt1"} },
+		"StateType":           func(r *common.FirewallRule) { r.StateType = "no state" },
+		"Direction":           func(r *common.FirewallRule) { r.Direction = common.DirectionOut },
+		"Protocol":            func(r *common.FirewallRule) { r.Protocol = "udp" },
+		"Quick":               func(r *common.FirewallRule) { r.Quick = false },
+		"Source.Address":      func(r *common.FirewallRule) { r.Source.Address = "any" },
+		"Source.Port":         func(r *common.FirewallRule) { r.Source.Port = "22" },
+		"Source.Negated":      func(r *common.FirewallRule) { r.Source.Negated = true },
+		"Destination.Address": func(r *common.FirewallRule) { r.Destination.Address = "any" },
+		"Destination.Port":    func(r *common.FirewallRule) { r.Destination.Port = "8080" },
+		"Destination.Negated": func(r *common.FirewallRule) { r.Destination.Negated = true },
+	}
+
+	for name, mutate := range mutations {
+		mutated := base
+		mutated.Interfaces = append([]string(nil), base.Interfaces...)
+		mutate(&mutated)
+		if hashRule(mutated) == h0 {
+			t.Errorf("mutation %q produced identical hash; field not covered by hashRule", name)
+		}
+	}
+}
+
+// TestHashRule_InterfaceBoundary guards against collisions where rules with
+// interfaces ["a","bc"] could hash the same as ["ab","c"] if segments were
+// concatenated without a separator.
+func TestHashRule_InterfaceBoundary(t *testing.T) {
+	t.Parallel()
+
+	r1 := baseHashRule()
+	r1.Interfaces = []string{"a", "bc"}
+	r2 := baseHashRule()
+	r2.Interfaces = []string{"ab", "c"}
+
+	if hashRule(r1) == hashRule(r2) {
+		t.Errorf("interface segmentation collision: hashRule did not preserve field boundaries")
+	}
+}


### PR DESCRIPTION
## Summary

Replaces the nested-loop duplicate firewall rule detection in `internal/analysis/detect.go` with a hash-bucketed algorithm. `DetectDeadRules` now runs in O(n) on the common case (distinct rules), while preserving byte-for-byte identical output to the prior implementation — same finding order, same `RuleIndex`, same `Description` text, including the pairwise emission contract for triplicate rules.

- New unexported `hashRule()` in `internal/analysis/rules.go` using FNV-64a over the same 14 fields `RulesEquivalent` compares, with NUL-delimited segment encoding to prevent boundary collisions.
- Bucketed detection in `DetectDeadRules`: prior rules are bucketed by hash; new rules only run `RulesEquivalent` against the matching bucket. Worst case (all-equivalent rules) remains O(n²), which is required anyway to emit the pairwise findings.
- Maintenance invariant documented on `hashRule`: extending `RulesEquivalent` without extending `hashRule` silently produces false negatives.

**Scope vs. ticket:** NATS-7 originally called for fixing two call sites. Issue #279 has since consolidated both into `internal/analysis/`, so only one site remained — exactly as the ticket's Notes anticipated.

## Benchmarks

Apple M5, distinct rules (common case):

| Rules | ns/op | Scaling |
|-------|-------|---------|
| 100   | 22,295 | — |
| 500   | 104,315 | 4.7× for 5× data |
| 1000  | 264,010 | 11.8× for 10× data |

Near-linear scaling confirmed; a true O(n²) would have shown 25× and 100×.

## Tests Added

- `TestHashRule_EquivalentRulesHashSame` — equivalent rules must share a hash
- `TestHashRule_DistinctRulesHashDifferently` — mutation table over all 14 `RulesEquivalent` fields
- `TestHashRule_InterfaceBoundary` — guards \`[\"a\",\"bc\"]\` vs \`[\"ab\",\"c\"]\` collision
- `TestDetectDeadRules_DisabledNotEquivalent` — disabled rule doesn't duplicate enabled
- `TestDetectDeadRules_CrossInterfaceDuplicates` — per-interface bucket reset invariant
- `TestDetectDeadRules_BlockAllPlusDuplicate` — mixed unreachable + duplicate path
- `TestDetectDeadRules_TriplicatePairwise` — tighter assertions on the 3-equivalent-rules case
- `BenchmarkDetectDeadRules_{100,500,1000}Rules`

## Test Plan

- [ ] `just ci-check` passes locally (verified)
- [ ] `go test -race ./...` passes (verified)
- [ ] Existing `TestDetectDeadRules` table tests unchanged and still pass
- [ ] Benchmark suite reports near-linear scaling

## Notes

- `cmd/config_validate.go` has cosmetic alignment changes applied by `golangci-lint fmt` (pre-existing drift surfaced by `just format-check`); unrelated to NATS-7 but included so `just ci-check` is green.