### PR TITLE
fix(firewall,schema): post-merge review feedback on NATS-77 (PR #571)

### DIFF
--- a/docs/firewall-security-controls-reference.md
+++ b/docs/firewall-security-controls-reference.md
@@ -262,11 +262,11 @@ opnDossier parses the OPNsense Unbound MVC configuration from `<OPNsense><unboun
 
 The check evaluates whether DNS rebind protection is configured:
 
-- **Pass**: Unbound is enabled AND the `privateaddress` list contains at least one valid entry
-- **Fail**: Unbound is enabled but `privateaddress` is empty or absent
-- **Unknown**: Unbound is disabled (the install may be using DNSMasq, which has its own rebind-protection mechanism)
+- **Pass**: Unbound is enabled AND the MVC `<privateaddress>` element was configured AND the list contains at least one valid entry.
+- **Fail**: Unbound is enabled AND the MVC `<privateaddress>` element was configured, but the list is empty (operator explicitly cleared it, or every entry failed CIDR/IP validation).
+- **Unknown**: Any of (a) Unbound is disabled — the install may be using DNSMasq, which has its own rebind-protection mechanism; (b) the MVC `<privateaddress>` element was never configured — common on older installs or minimal setups that have not touched the Unbound advanced block.
 
-A finding is emitted when the check fails (`cr.Known && !cr.Result` in `internal/plugins/firewall/firewall.go`) — i.e. when Unbound is active but rebind protection is missing.
+A finding is emitted when the check fails (`cr.Known && !cr.Result` in `internal/plugins/firewall/firewall.go`) — i.e., when Unbound is active AND the element was configured AND the resulting list is empty.
 
 ### Recommended Action
 

--- a/pkg/parser/opnsense/converter_test.go
+++ b/pkg/parser/opnsense/converter_test.go
@@ -726,9 +726,11 @@ func TestConverter_DNS_PrivateAddressPresentEmpty(t *testing.T) {
 	t.Parallel()
 
 	// When <privateaddress></privateaddress> is present but empty, the
-	// converter records PrivateAddressConfigured=true with an empty slice,
-	// so downstream FIREWALL-007 can return Fail (operator explicitly
-	// cleared the list).
+	// converter records PrivateAddressConfigured=true while `PrivateAddress`
+	// itself stays nil (splitPrivateAddress returns nil on empty input).
+	// Downstream FIREWALL-007 uses the Configured flag to distinguish this
+	// "operator explicitly cleared" case (Fail) from the absent-element case
+	// (Unknown).
 	doc := schema.NewOpnSenseDocument()
 	doc.Unbound.Enable = "1"
 	empty := ""

--- a/pkg/schema/opnsense/unboundplus.go
+++ b/pkg/schema/opnsense/unboundplus.go
@@ -110,7 +110,7 @@ type UnboundPlusAdvanced struct {
 	// but empty ("configured, cleared out") — see GOTCHAS 3.2. The converter
 	// carries this distinction through to common.UnboundConfig so the firewall
 	// plugin can treat unknown and configured-empty differently.
-	Privateaddress         *string `xml:"privateaddress"         json:"privateaddress,omitempty"`
+	Privateaddress         *string `xml:"privateaddress"         json:",omitempty"`
 	Insecuredomain         string  `xml:"insecuredomain"`         // separator-delimited domain list
 	Msgcachesize           string  `xml:"msgcachesize"`           // bytes, decimal
 	Rrsetcachesize         string  `xml:"rrsetcachesize"`         // bytes, decimal

--- a/pkg/schema/opnsense/unboundplus_test.go
+++ b/pkg/schema/opnsense/unboundplus_test.go
@@ -63,6 +63,20 @@ func TestUnboundPlus_UnmarshalXML(t *testing.T) {
 	assert.Equal(t, "allow", got.Acls.DefaultAction)
 	assert.Equal(t, "ads", got.Dnsbl.Type)
 	assert.Equal(t, "0", got.Forwarding.Enabled)
+
+	// Present-but-empty container elements must deserialize to non-nil
+	// pointers pointing to empty strings — this is the contract the *string
+	// promotion exists to protect (GOTCHAS 3.2). A regression that reverted
+	// to plain `string` would still fail this assertion because string zero
+	// value is "", not a non-nil pointer.
+	require.NotNil(t, got.Dots)
+	require.NotNil(t, got.Hosts)
+	require.NotNil(t, got.Aliases)
+	require.NotNil(t, got.Domains)
+	assert.Empty(t, *got.Dots)
+	assert.Empty(t, *got.Hosts)
+	assert.Empty(t, *got.Aliases)
+	assert.Empty(t, *got.Domains)
 }
 
 func TestUnboundPlus_EmptyElement(t *testing.T) {
@@ -75,6 +89,12 @@ func TestUnboundPlus_EmptyElement(t *testing.T) {
 	assert.Empty(t, got.General.Enabled)
 	assert.Nil(t, got.Advanced.Privateaddress)
 	assert.Empty(t, got.Acls.DefaultAction)
+	// Absent container elements must deserialize to nil pointers so callers
+	// can distinguish "never configured" from "present but empty".
+	assert.Nil(t, got.Dots)
+	assert.Nil(t, got.Hosts)
+	assert.Nil(t, got.Aliases)
+	assert.Nil(t, got.Domains)
 }
 
 func TestUnboundPlus_RoundTrip(t *testing.T) {

--- a/pkg/schema/opnsense/unboundplus_test.go
+++ b/pkg/schema/opnsense/unboundplus_test.go
@@ -66,9 +66,12 @@ func TestUnboundPlus_UnmarshalXML(t *testing.T) {
 
 	// Present-but-empty container elements must deserialize to non-nil
 	// pointers pointing to empty strings — this is the contract the *string
-	// promotion exists to protect (GOTCHAS 3.2). A regression that reverted
-	// to plain `string` would still fail this assertion because string zero
-	// value is "", not a non-nil pointer.
+	// promotion exists to protect (GOTCHAS 3.2). The NotNil checks confirm
+	// the XML elements were present and unmarshaled into populated pointers.
+	// If these fields regressed to plain `string`, NotNil could still pass
+	// because a string stored in an interface{} is non-nil; the real guard
+	// is the dereference below, which requires the fields to remain *string
+	// or the test will fail to compile.
 	require.NotNil(t, got.Dots)
 	require.NotNil(t, got.Hosts)
 	require.NotNil(t, got.Aliases)


### PR DESCRIPTION
## Summary

PR #571 (NATS-77) merged before five review threads could be addressed on-branch. This follow-up rolls them into a small focused PR.

| # | Location | Issue | Fix |
|---|---|---|---|
| 1 | `pkg/schema/opnsense/unboundplus.go` | `Privateaddress` json tag was `\"privateaddress,omitempty\"` — downcased the key, breaking the PascalCase convention documented in the file header | Changed to `json:\",omitempty\"` (keeps Go field name, still omits nil pointers) |
| 2 | `docs/firewall-security-controls-reference.md` | FIREWALL-007 Pass/Fail/Unknown bullets didn't reflect the `PrivateAddressConfigured` gate — instructed users that an absent `<privateaddress>` element is a Fail | Rewrote to match plugin behavior: absent → Unknown, configured-but-empty → Fail |
| 3 | `pkg/parser/opnsense/converter_test.go` | Test comment said \"empty slice\" but `splitPrivateAddress` returns `nil` | Reworded comment to reflect the actual contract |
| 4, 5 | `pkg/schema/opnsense/unboundplus_test.go` | No assertions that present-but-empty container pointers (Dots/Hosts/Aliases/Domains) deserialize to non-nil `*string` values, or that absent containers stay nil | Added explicit `NotNil`+empty and `Nil` assertions in both the UnmarshalXML and EmptyElement tests |

## Why a follow-up instead of amending #571

The merge queue consumed #571 while these threads were being addressed. Rather than revert-and-reland, these are surgical enough to ship as their own PR.

## Test plan

- [x] `just ci-check` clean locally (lint + pre-commit + full test suite, incl. `-race`)
- [x] New test cases cover both sides of the `*string` contract (present-but-empty → non-nil, absent → nil)
- [x] Docs match `hasDNSRebindProtection` behavior byte-for-byte

## Thread resolution

Once this merges I'll resolve the five PR #571 threads referencing it.

[NATS-77]: https://evilbitlabs.atlassian.net/browse/NATS-77

---

![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)