### PR TITLE
perf(converter): NATS-38 cut firewall-row allocations 41% via formatter and converter idioms

### DIFF
--- a/internal/analysis/statistics.go
+++ b/internal/analysis/statistics.go
@@ -40,6 +40,15 @@ func ComputeStatistics(cfg *common.CommonDevice) *common.Statistics {
 // Factored out so the nil-cfg early return and the populated path both share
 // the same initializer — any new map/slice added here is guaranteed to be
 // non-nil on both paths.
+//
+// The maps intentionally use the no-hint form. NATS-38 evaluated
+// pre-sizing them via len(cfg.Interfaces) and small-cardinality
+// constants; BenchmarkComputeStatistics showed no measurable gain on
+// realistic interface counts (3-30), and an iface-derived hint added
+// +1 alloc on the 100-fixture (10 interfaces) because Go pre-allocates
+// a separate bucket array once the hint crosses bucketCnt (8). Empty
+// maps stay header-only with no hint, which is already optimal for
+// the opnsense/pfSense distribution.
 func newStatistics() *common.Statistics {
 	return &common.Statistics{
 		InterfacesByType: make(map[string]int),

--- a/internal/analysis/statistics.go
+++ b/internal/analysis/statistics.go
@@ -41,14 +41,9 @@ func ComputeStatistics(cfg *common.CommonDevice) *common.Statistics {
 // the same initializer — any new map/slice added here is guaranteed to be
 // non-nil on both paths.
 //
-// The maps intentionally use the no-hint form. NATS-38 evaluated
-// pre-sizing them via len(cfg.Interfaces) and small-cardinality
-// constants; BenchmarkComputeStatistics showed no measurable gain on
-// realistic interface counts (3-30), and an iface-derived hint added
-// +1 alloc on the 100-fixture (10 interfaces) because Go pre-allocates
-// a separate bucket array once the hint crosses bucketCnt (8). Empty
-// maps stay header-only with no hint, which is already optimal for
-// the opnsense/pfSense distribution.
+// The maps intentionally use the no-hint form; pre-sizing with
+// len(cfg.Interfaces) was measured to regress the common 3-30
+// interface case. See BenchmarkComputeStatistics for the rationale.
 func newStatistics() *common.Statistics {
 	return &common.Statistics{
 		InterfacesByType: make(map[string]int),

--- a/internal/analysis/statistics_bench_test.go
+++ b/internal/analysis/statistics_bench_test.go
@@ -69,7 +69,7 @@ func BenchmarkComputeStatistics(b *testing.B) {
 		b.Run(strconv.Itoa(size), func(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
-			for range b.N {
+			for b.Loop() {
 				_ = ComputeStatistics(cfg)
 			}
 		})
@@ -79,7 +79,7 @@ func BenchmarkComputeStatistics(b *testing.B) {
 func BenchmarkComputeStatisticsNil(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
-	for range b.N {
+	for b.Loop() {
 		_ = ComputeStatistics(nil)
 	}
 }

--- a/internal/analysis/statistics_bench_test.go
+++ b/internal/analysis/statistics_bench_test.go
@@ -4,14 +4,17 @@
 // early return for nil cfg (no maps populated) and a populated path
 // with realistic interface and firewall-rule counts.
 //
-// History: NATS-38 considered pre-sizing the per-statistic maps via
-// len(cfg.Interfaces) and small-cardinality enum constants. Bench
-// measurements with the hint added showed:
+// History: pre-sizing the per-statistic maps via len(cfg.Interfaces)
+// and small-cardinality enum constants was evaluated and reverted.
+// Bench measurements with the hint added showed:
 //
 //   - 100-fixture (10 interfaces, 100 rules): 19 -> 20 allocs/op
-//     (+1, regression). The iface-derived hint (10) crossed Go's
-//     bucketCnt threshold of 8, forcing an immediate separate
-//     bucket-array allocation that the no-hint path avoided entirely.
+//     (+1, regression). Go's runtime sizes the inline bucket of an
+//     hmap to hold 8 key/value pairs; make(map[K]V, hint) with hint
+//     <= 8 produces 0 extra allocations, but hint >= 9 forces an
+//     immediate separate bucket-array allocation that the no-hint
+//     path avoids entirely. The iface-derived hint of 10 fell over
+//     this boundary.
 //   - 500-fixture (50 interfaces, 500 rules): 25 -> 22 allocs/op
 //     (-3, win). The hint avoided three rehash-grow cycles.
 //   - nil cfg: 6 -> 6 allocs/op (no change).
@@ -68,7 +71,6 @@ func BenchmarkComputeStatistics(b *testing.B) {
 		cfg := generateStatsFixture(size/10, size)
 		b.Run(strconv.Itoa(size), func(b *testing.B) {
 			b.ReportAllocs()
-			b.ResetTimer()
 			for b.Loop() {
 				_ = ComputeStatistics(cfg)
 			}
@@ -78,7 +80,6 @@ func BenchmarkComputeStatistics(b *testing.B) {
 
 func BenchmarkComputeStatisticsNil(b *testing.B) {
 	b.ReportAllocs()
-	b.ResetTimer()
 	for b.Loop() {
 		_ = ComputeStatistics(nil)
 	}

--- a/internal/analysis/statistics_bench_test.go
+++ b/internal/analysis/statistics_bench_test.go
@@ -1,0 +1,85 @@
+// Benchmarks for ComputeStatistics.
+//
+// BenchmarkComputeStatistics covers the two map-allocation paths — the
+// early return for nil cfg (no maps populated) and a populated path
+// with realistic interface and firewall-rule counts.
+//
+// History: NATS-38 considered pre-sizing the per-statistic maps via
+// len(cfg.Interfaces) and small-cardinality enum constants. Bench
+// measurements with the hint added showed:
+//
+//   - 100-fixture (10 interfaces, 100 rules): 19 -> 20 allocs/op
+//     (+1, regression). The iface-derived hint (10) crossed Go's
+//     bucketCnt threshold of 8, forcing an immediate separate
+//     bucket-array allocation that the no-hint path avoided entirely.
+//   - 500-fixture (50 interfaces, 500 rules): 25 -> 22 allocs/op
+//     (-3, win). The hint avoided three rehash-grow cycles.
+//   - nil cfg: 6 -> 6 allocs/op (no change).
+//
+// Real-world opnsense/pfSense configurations sit in the 3-30 interface
+// range, where the 100-fixture regression dominates the 500-fixture
+// win. The ticket's premise (pre-size maps to known element counts)
+// only pays off for unusually-interface-rich configurations, so the
+// hints were not landed. The bench file stays so a future contributor
+// does not retry the experiment without seeing this result.
+package analysis
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	common "github.com/EvilBit-Labs/opnDossier/pkg/model"
+)
+
+func generateStatsFixture(interfaceCount, ruleCount int) *common.CommonDevice {
+	cfg := &common.CommonDevice{}
+	cfg.Interfaces = make([]common.Interface, 0, interfaceCount)
+	for i := range interfaceCount {
+		cfg.Interfaces = append(cfg.Interfaces, common.Interface{
+			Name:    fmt.Sprintf("iface%d", i),
+			Type:    "static",
+			Enabled: true,
+		})
+	}
+
+	cfg.FirewallRules = make([]common.FirewallRule, 0, ruleCount)
+	for i := range ruleCount {
+		cfg.FirewallRules = append(cfg.FirewallRules, common.FirewallRule{
+			Type:        common.RuleTypePass,
+			Interfaces:  []string{fmt.Sprintf("iface%d", i%interfaceCount)},
+			Description: "rule " + strconv.Itoa(i),
+		})
+	}
+
+	cfg.Users = []common.User{
+		{Name: "admin", Scope: "system"},
+		{Name: "user1", Scope: "user"},
+	}
+	cfg.Groups = []common.Group{
+		{Name: "admins", Scope: "system"},
+	}
+
+	return cfg
+}
+
+func BenchmarkComputeStatistics(b *testing.B) {
+	for _, size := range []int{100, 500} {
+		cfg := generateStatsFixture(size/10, size)
+		b.Run(strconv.Itoa(size), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				_ = ComputeStatistics(cfg)
+			}
+		})
+	}
+}
+
+func BenchmarkComputeStatisticsNil(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		_ = ComputeStatistics(nil)
+	}
+}

--- a/internal/converter/builder/builder_security_bench_test.go
+++ b/internal/converter/builder/builder_security_bench_test.go
@@ -56,7 +56,7 @@ func BenchmarkFirewallRulesTable(b *testing.B) {
 		b.Run(strconv.Itoa(size), func(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
-			for range b.N {
+			for b.Loop() {
 				_ = BuildFirewallRulesTableSet(rules)
 			}
 		})

--- a/internal/converter/builder/builder_security_bench_test.go
+++ b/internal/converter/builder/builder_security_bench_test.go
@@ -49,13 +49,57 @@ func generateFirewallRules(n int) []common.FirewallRule {
 
 // BenchmarkFirewallRulesTable measures the allocs/op and ns/op cost of
 // BuildFirewallRulesTableSet for representative table sizes. The 500-row
-// sub-bench is the merge gate for NATS-38 (R2: ≥30% allocs/op reduction).
+// sub-bench is the merge gate for the firewall-rule allocation work
+// (>=30% allocs/op reduction target).
 func BenchmarkFirewallRulesTable(b *testing.B) {
 	for _, size := range []int{100, 500} {
 		rules := generateFirewallRules(size)
 		b.Run(strconv.Itoa(size), func(b *testing.B) {
 			b.ReportAllocs()
-			b.ResetTimer()
+			for b.Loop() {
+				_ = BuildFirewallRulesTableSet(rules)
+			}
+		})
+	}
+}
+
+// generateFirewallRulesWithInterfaceCount returns n rules whose Interfaces
+// slices have the requested length, exercising the FormatInterfacesAsLinks
+// branches for the empty-slice early return (count=0), single-link path
+// (count=1), and multi-link separator path (count>=2).
+func generateFirewallRulesWithInterfaceCount(n, ifaceCount int) []common.FirewallRule {
+	rules := make([]common.FirewallRule, 0, n)
+	for i := range n {
+		ifaces := make([]string, 0, ifaceCount)
+		for j := range ifaceCount {
+			if j == 0 {
+				ifaces = append(ifaces, "wan")
+			} else {
+				ifaces = append(ifaces, fmt.Sprintf("opt%d", j-1))
+			}
+		}
+		rules = append(rules, common.FirewallRule{
+			UUID:        fmt.Sprintf("rule-%d", i),
+			Type:        common.RuleTypePass,
+			Protocol:    "tcp",
+			Interfaces:  ifaces,
+			Source:      common.RuleEndpoint{Address: "10.0.0.0/24", Port: "any"},
+			Destination: common.RuleEndpoint{Address: "192.168.1.10", Port: "443"},
+			Description: fmt.Sprintf("rule %d", i),
+		})
+	}
+	return rules
+}
+
+// BenchmarkFirewallRulesTable_InterfaceCount exercises the
+// FormatInterfacesAsLinks paths the main bench under-covers — empty
+// slice, single-element, and multi-element — at a fixed row count.
+func BenchmarkFirewallRulesTable_InterfaceCount(b *testing.B) {
+	const rowCount = 100
+	for _, ifaceCount := range []int{0, 1, 4} {
+		rules := generateFirewallRulesWithInterfaceCount(rowCount, ifaceCount)
+		b.Run("ifaces="+strconv.Itoa(ifaceCount), func(b *testing.B) {
+			b.ReportAllocs()
 			for b.Loop() {
 				_ = BuildFirewallRulesTableSet(rules)
 			}

--- a/internal/converter/builder/builder_security_bench_test.go
+++ b/internal/converter/builder/builder_security_bench_test.go
@@ -1,0 +1,64 @@
+// Benchmarks for the firewall-rules markdown table builder.
+//
+// BenchmarkFirewallRulesTable is the merge gate for NATS-38: it locks in the
+// allocs/op baseline before the per-row formatter optimisations land and is
+// re-run afterwards to validate the ≥30% allocs/op reduction target on the
+// 500-row sub-bench.
+package builder
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	common "github.com/EvilBit-Labs/opnDossier/pkg/model"
+)
+
+// generateFirewallRules returns n synthetic firewall rules with field shapes
+// that exercise every formatter the per-row hot loop calls — multi-interface
+// lists for FormatInterfacesAsLinks, descriptions with markdown-special
+// characters for EscapeTableContent, mixed Disabled flags for
+// FormatBoolInverted, and non-empty source/destination ports for the two
+// EscapeTableContent calls on port fields.
+//
+// The fixture is deterministic so benchmark runs are comparable.
+func generateFirewallRules(n int) []common.FirewallRule {
+	rules := make([]common.FirewallRule, 0, n)
+	for i := range n {
+		rules = append(rules, common.FirewallRule{
+			UUID:        fmt.Sprintf("rule-%d", i),
+			Type:        common.RuleTypePass,
+			IPProtocol:  common.IPProtocolInet,
+			Protocol:    "tcp",
+			Interfaces:  []string{"wan", fmt.Sprintf("opt%d", i%4)},
+			Source:      common.RuleEndpoint{Address: fmt.Sprintf("10.0.%d.0/24", i%256), Port: "any"},
+			Destination: common.RuleEndpoint{Address: "192.168.1.10", Port: strconv.Itoa(1024 + (i % 64512))},
+			Target:      "",
+			// Description includes markdown specials (pipe, asterisk, brackets,
+			// backtick, underscore) so EscapeTableContent does real work.
+			Description: fmt.Sprintf(
+				"rule %d | allow *web* [_HTTPS_] `https://10.0.%d.0/24` -> 192.168.1.10:443",
+				i,
+				i%256,
+			),
+			Disabled: i%5 == 0,
+		})
+	}
+	return rules
+}
+
+// BenchmarkFirewallRulesTable measures the allocs/op and ns/op cost of
+// BuildFirewallRulesTableSet for representative table sizes. The 500-row
+// sub-bench is the merge gate for NATS-38 (R2: ≥30% allocs/op reduction).
+func BenchmarkFirewallRulesTable(b *testing.B) {
+	for _, size := range []int{100, 500} {
+		rules := generateFirewallRules(size)
+		b.Run(strconv.Itoa(size), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				_ = BuildFirewallRulesTableSet(rules)
+			}
+		})
+	}
+}

--- a/internal/converter/formatters/formatters.go
+++ b/internal/converter/formatters/formatters.go
@@ -6,8 +6,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/nao1215/markdown"
 )
 
 // Display symbols and boolean string representations used for formatting report output.
@@ -25,18 +23,49 @@ const (
 // Each interface name is converted to a clickable link that references the corresponding interface configuration section.
 // The function returns inline markdown links (e.g., [wan](#wan-interface)), which the nao1215/markdown package
 // automatically converts to reference-style links when used in table cells.
+//
+// Implementation note: this is a hot path inside per-row markdown table
+// builders. The body uses a pre-grown strings.Builder rather than
+// markdown.Link + strings.Join to avoid the intermediate []string and
+// the per-link string allocations the markdown helper performs. Output
+// is byte-identical to the prior markdown.Link / strings.Join form.
 func FormatInterfacesAsLinks(interfaces []string) string {
 	if len(interfaces) == 0 {
 		return ""
 	}
 
-	links := make([]string, 0, len(interfaces))
+	// Per-link literal overhead: "[](#-interface)" = 15 bytes, plus the
+	// interface name appears twice (display label + anchor slug). Inter-
+	// link separator ", " adds 2 bytes between entries.
+	const (
+		perLinkOverhead = 15
+		ifaceCopies     = 2
+		separatorBytes  = 2
+	)
+	estimated := 0
 	for _, iface := range interfaces {
-		anchor := "#" + strings.ToLower(iface) + "-interface"
-		links = append(links, markdown.Link(iface, anchor))
+		estimated += ifaceCopies*len(iface) + perLinkOverhead
+	}
+	if len(interfaces) > 1 {
+		estimated += separatorBytes * (len(interfaces) - 1)
 	}
 
-	return strings.Join(links, ", ")
+	var b strings.Builder
+	b.Grow(estimated)
+	for i, iface := range interfaces {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteByte('[')
+		b.WriteString(iface)
+		b.WriteString("](#")
+		// strings.ToLower returns the original string unchanged when it
+		// has no uppercase runes, so already-lowercase interface names
+		// pay no allocation here.
+		b.WriteString(strings.ToLower(iface))
+		b.WriteString("-interface)")
+	}
+	return b.String()
 }
 
 // FormatBoolean formats a boolean value for display in markdown tables.

--- a/internal/converter/formatters/formatters_test.go
+++ b/internal/converter/formatters/formatters_test.go
@@ -32,6 +32,15 @@ func TestFormatInterfacesAsLinks(t *testing.T) {
 			interfaces: []string{"WAN"},
 			want:       "[WAN](#wan-interface)",
 		},
+		{
+			// Pins the byte-identity invariant after the strings.Builder
+			// rewrite replaced markdown.Link / strings.Join. The output
+			// must remain "[<label>](#<lower>-interface), ..." for every
+			// element including mixed case.
+			name:       "mixed case multi-element",
+			interfaces: []string{"WAN", "lan", "OPT1"},
+			want:       "[WAN](#wan-interface), [lan](#lan-interface), [OPT1](#opt1-interface)",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/converter/formatters/utils.go
+++ b/internal/converter/formatters/utils.go
@@ -7,6 +7,13 @@ import (
 	"strings"
 )
 
+// stringEscape applies the table-content escape rules to a single string.
+// Both fast paths in EscapeTableContent share this helper so the escape
+// strategy stays defined in one place.
+func stringEscape(s string) string {
+	return strings.TrimSpace(escapeTableReplacer.Replace(s))
+}
+
 // Pre-compiled regex for SanitizeID to avoid repeated compilation.
 // This pattern matches any sequence of non-alphanumeric characters.
 var sanitizeIDRegex = regexp.MustCompile(`[^a-zA-Z0-9]+`)
@@ -32,21 +39,27 @@ var escapeTableReplacer = strings.NewReplacer(
 // EscapeTableContent escapes content for safe display in markdown tables.
 // This function ensures that special Markdown characters don't break table formatting or rendering.
 //
-// The string fast path skips fmt.Sprintf("%v", ...) reflection boxing —
-// every caller in the per-row markdown table loops passes an already-
-// typed string, so the fmt machinery is pure overhead for the hot path.
+// Two fast paths skip fmt.Sprintf("%v", ...) reflection boxing for
+// string-kind inputs — the unnamed string path covers the common
+// per-row formatter callers, and the reflect.Kind == String path
+// covers named string types like FirewallRuleType, IPProtocol, and
+// VIPMode that the markdown table builders also pass through. fmt
+// machinery is pure overhead for both shapes; reflection is cheaper
+// than fmt.Sprintf for the named-string case.
 func EscapeTableContent(content any) string {
 	if content == nil {
 		return ""
 	}
 
 	if s, ok := content.(string); ok {
-		return strings.TrimSpace(escapeTableReplacer.Replace(s))
+		return stringEscape(s)
 	}
 
-	str := fmt.Sprintf("%v", content)
+	if v := reflect.ValueOf(content); v.Kind() == reflect.String {
+		return stringEscape(v.String())
+	}
 
-	return strings.TrimSpace(escapeTableReplacer.Replace(str))
+	return stringEscape(fmt.Sprintf("%v", content))
 }
 
 // TruncateDescription truncates a description to the specified maximum length,

--- a/internal/converter/formatters/utils.go
+++ b/internal/converter/formatters/utils.go
@@ -31,9 +31,17 @@ var escapeTableReplacer = strings.NewReplacer(
 
 // EscapeTableContent escapes content for safe display in markdown tables.
 // This function ensures that special Markdown characters don't break table formatting or rendering.
+//
+// The string fast path skips fmt.Sprintf("%v", ...) reflection boxing —
+// every caller in the per-row markdown table loops passes an already-
+// typed string, so the fmt machinery is pure overhead for the hot path.
 func EscapeTableContent(content any) string {
 	if content == nil {
 		return ""
+	}
+
+	if s, ok := content.(string); ok {
+		return strings.TrimSpace(escapeTableReplacer.Replace(s))
 	}
 
 	str := fmt.Sprintf("%v", content)

--- a/internal/converter/formatters/utils_bench_test.go
+++ b/internal/converter/formatters/utils_bench_test.go
@@ -1,0 +1,44 @@
+// Benchmarks for EscapeTableContent dispatch paths.
+//
+// EscapeTableContent has three meaningful paths: nil, the unnamed-string
+// fast path (covers the per-row markdown table callers), the
+// reflect-based string-kind path (covers named string types like
+// FirewallRuleType, IPProtocol, VIPMode), and the fmt.Sprintf fallback
+// (covers ints, bools, etc.). The benchmarks below pin the relative
+// alloc costs so a future refactor reordering the type switch surfaces
+// the regression on its own.
+package formatters
+
+import "testing"
+
+type benchNamedString string
+
+func BenchmarkEscapeTableContent_String(b *testing.B) {
+	const s = "rule 42 | allow *web* [_HTTPS_]"
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = EscapeTableContent(s)
+	}
+}
+
+func BenchmarkEscapeTableContent_NamedString(b *testing.B) {
+	const s benchNamedString = "rule 42 | allow *web* [_HTTPS_]"
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = EscapeTableContent(s)
+	}
+}
+
+func BenchmarkEscapeTableContent_Int(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = EscapeTableContent(42)
+	}
+}
+
+func BenchmarkEscapeTableContent_Nil(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = EscapeTableContent(nil)
+	}
+}

--- a/internal/converter/formatters/utils_test.go
+++ b/internal/converter/formatters/utils_test.go
@@ -5,6 +5,13 @@ import (
 	"testing"
 )
 
+// namedString stands in for opnsense FirewallRuleType, IPProtocol, or
+// pfsense VIPMode in EscapeTableContent tests — it is a string-kind
+// alias whose unnamed-string type assertion fails but whose
+// reflect.Kind() returns reflect.String. The reflect-based fast path
+// must accept it without falling through to fmt.Sprintf.
+type namedString string
+
 func TestEscapeTableContent(t *testing.T) {
 	t.Parallel()
 
@@ -26,6 +33,14 @@ func TestEscapeTableContent(t *testing.T) {
 		{"empty string", "", ""},
 		{"multiple escapes", "*test_file|name*", "\\*test\\_file\\|name\\*"},
 		{"whitespace only", "  \n\r  ", ""},
+		// Named string types (e.g. opnsense FirewallRuleType, IPProtocol,
+		// VIPMode) are passed through EscapeTableContent by some markdown
+		// table builders. The reflect.Kind == String fast path must
+		// produce the same output as the unnamed-string and fmt.Sprintf
+		// paths.
+		{"named string type plain", namedString("plain"), "plain"},
+		{"named string type with specials", namedString("a|b*c"), "a\\|b\\*c"},
+		{"named string type empty", namedString(""), ""},
 	}
 
 	for _, tt := range tests {

--- a/internal/processor/report.go
+++ b/internal/processor/report.go
@@ -96,13 +96,9 @@ func NewReport(cfg *common.CommonDevice, processorConfig Config) *Report {
 	report := &Report{
 		GeneratedAt:     time.Now().UTC(),
 		ProcessorConfig: processorConfig,
-		// Per-severity slices intentionally use zero-cap make so an
-		// empty report stays a single 288 B allocation. Pre-sizing with
-		// capacity hints (e.g. 4/8/16/32/16) was measured against
-		// BenchmarkNewReport and made the empty-report path 6× more
-		// allocations and ~50× more bytes — most reports surface 0-3
-		// findings per severity, so eager preallocation is wasted heap.
-		// See NATS-38 plan U2 negative result.
+		// Per-severity slices intentionally use zero-cap make. Adding
+		// capacity hints regresses the common empty-report path; see
+		// BenchmarkNewReport for the measurement.
 		Findings: Findings{
 			Critical: make([]Finding, 0),
 			High:     make([]Finding, 0),

--- a/internal/processor/report.go
+++ b/internal/processor/report.go
@@ -96,6 +96,13 @@ func NewReport(cfg *common.CommonDevice, processorConfig Config) *Report {
 	report := &Report{
 		GeneratedAt:     time.Now().UTC(),
 		ProcessorConfig: processorConfig,
+		// Per-severity slices intentionally use zero-cap make so an
+		// empty report stays a single 288 B allocation. Pre-sizing with
+		// capacity hints (e.g. 4/8/16/32/16) was measured against
+		// BenchmarkNewReport and made the empty-report path 6× more
+		// allocations and ~50× more bytes — most reports surface 0-3
+		// findings per severity, so eager preallocation is wasted heap.
+		// See NATS-38 plan U2 negative result.
 		Findings: Findings{
 			Critical: make([]Finding, 0),
 			High:     make([]Finding, 0),

--- a/internal/processor/report_bench_test.go
+++ b/internal/processor/report_bench_test.go
@@ -1,0 +1,38 @@
+// Benchmarks for processor.Report construction.
+//
+// BenchmarkNewReport pins the empty-report allocation cost so a future
+// contributor does not re-introduce per-severity capacity hints on the
+// Findings slices.
+//
+// History: NATS-38 considered hints of 4/8/16/32/16 to amortize early
+// AddFinding appends. Bench measurement showed the opposite — make([]T,
+// 0) is a zero-allocation zero-cap slice in Go, while make([]T, 0, N)
+// forces an N*sizeof(Finding) heap allocation up front. Pre-sizing 76
+// finding slots eagerly cost 6 allocs/op + 14688 B/op vs the
+// no-capacity baseline of 1 alloc/op + 288 B/op. Most reports surface
+// 0-3 findings per severity, so the hints would over-allocate on every
+// call.
+package processor
+
+import (
+	"testing"
+
+	common "github.com/EvilBit-Labs/opnDossier/pkg/model"
+)
+
+func BenchmarkNewReport(b *testing.B) {
+	cfg := &common.CommonDevice{
+		Version:    "test",
+		DeviceType: common.DeviceTypeOPNsense,
+	}
+	cfg.System.Hostname = "bench"
+	cfg.System.Domain = "example.com"
+
+	pc := Config{EnableStats: false}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		_ = NewReport(cfg, pc)
+	}
+}

--- a/internal/processor/report_bench_test.go
+++ b/internal/processor/report_bench_test.go
@@ -32,7 +32,7 @@ func BenchmarkNewReport(b *testing.B) {
 
 	b.ReportAllocs()
 	b.ResetTimer()
-	for range b.N {
+	for b.Loop() {
 		_ = NewReport(cfg, pc)
 	}
 }

--- a/internal/processor/report_bench_test.go
+++ b/internal/processor/report_bench_test.go
@@ -31,7 +31,6 @@ func BenchmarkNewReport(b *testing.B) {
 	pc := Config{EnableStats: false}
 
 	b.ReportAllocs()
-	b.ResetTimer()
 	for b.Loop() {
 		_ = NewReport(cfg, pc)
 	}

--- a/pkg/parser/opnsense/converter.go
+++ b/pkg/parser/opnsense/converter.go
@@ -3,7 +3,6 @@ package opnsense
 import (
 	"errors"
 	"fmt"
-	"maps"
 	"slices"
 	"strings"
 
@@ -161,8 +160,17 @@ func (c *converter) convertInterfaces(doc *schema.OpnSenseDocument) []common.Int
 		return nil
 	}
 
+	// Collect-then-sort uses a single allocation. slices.Sorted(maps.Keys)
+	// allocates the iter.Seq closure plus grows the result slice during
+	// collect — measured 7-11 allocs vs 1 across 8-128 entry maps.
+	keys := make([]string, 0, len(items))
+	for k := range items {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+
 	result := make([]common.Interface, 0, len(items))
-	for _, key := range slices.Sorted(maps.Keys(items)) {
+	for _, key := range keys {
 		iface := items[key]
 		result = append(result, common.Interface{
 			Name:         key,

--- a/pkg/parser/opnsense/converter_services.go
+++ b/pkg/parser/opnsense/converter_services.go
@@ -2,7 +2,6 @@ package opnsense
 
 import (
 	"fmt"
-	"maps"
 	"net/netip"
 	"slices"
 	"strings"
@@ -31,7 +30,14 @@ func (c *converter) convertDHCP(doc *schema.OpnSenseDocument) []common.DHCPScope
 	}
 
 	result := make([]common.DHCPScope, 0, len(items))
-	for _, key := range slices.Sorted(maps.Keys(items)) {
+	// Single-allocation sorted-keys idiom; see comment in convertInterfaces.
+	keys := make([]string, 0, len(items))
+	for k := range items {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+
+	for _, key := range keys {
 		d := items[key]
 		scope := common.DHCPScope{
 			Interface:  key,

--- a/pkg/parser/opnsense/converter_subsystems.go
+++ b/pkg/parser/opnsense/converter_subsystems.go
@@ -2,7 +2,6 @@ package opnsense
 
 import (
 	"fmt"
-	"maps"
 	"slices"
 	"strings"
 
@@ -299,7 +298,14 @@ func (c *converter) convertKeaDHCPScopes(doc *schema.OpnSenseDocument) []common.
 		}
 	}
 
-	for _, subnetUUID := range slices.Sorted(maps.Keys(resBySubnet)) {
+	// Single-allocation sorted-keys idiom; see convertInterfaces.
+	subnetUUIDs := make([]string, 0, len(resBySubnet))
+	for k := range resBySubnet {
+		subnetUUIDs = append(subnetUUIDs, k)
+	}
+	slices.Sort(subnetUUIDs)
+
+	for _, subnetUUID := range subnetUUIDs {
 		if _, ok := seenSubnets[subnetUUID]; !ok {
 			c.addWarning(
 				"kea.dhcp4.reservations",

--- a/pkg/parser/opnsense/converter_test.go
+++ b/pkg/parser/opnsense/converter_test.go
@@ -111,17 +111,16 @@ func TestConverter_Interfaces(t *testing.T) {
 	device, warnings, err := opnsense.ConvertDocument(doc)
 	require.NoError(t, err)
 	assert.Empty(t, warnings)
-	assert.Len(t, device.Interfaces, 2)
+	require.Len(t, device.Interfaces, 2)
 
-	// Find the WAN interface by name
-	var wan *common.Interface
-	for i := range device.Interfaces {
-		if device.Interfaces[i].Name == "wan" {
-			wan = &device.Interfaces[i]
-			break
-		}
-	}
-	require.NotNil(t, wan, "wan interface not found")
+	// convertInterfaces sorts the result by interface name to keep
+	// output deterministic across map-iteration orderings. Assert
+	// positional order so a future regression in the sort step shows
+	// up here, not silently in downstream golden output.
+	assert.Equal(t, "lan", device.Interfaces[0].Name, "interfaces should be sorted lexicographically")
+	assert.Equal(t, "wan", device.Interfaces[1].Name, "interfaces should be sorted lexicographically")
+
+	wan := &device.Interfaces[1]
 	assert.Equal(t, "igb0", wan.PhysicalIf)
 	assert.Equal(t, "WAN", wan.Description)
 	assert.True(t, wan.Enabled)
@@ -246,6 +245,9 @@ func TestConverter_DHCP(t *testing.T) {
 	t.Parallel()
 
 	doc := schema.NewOpnSenseDocument()
+	// Two scopes are required to exercise the sorted-keys idiom in
+	// convertDHCP — a single-entry fixture would sort correctly under
+	// any algorithm and could not catch an ordering regression.
 	doc.Dhcpd.Items["lan"] = schema.DhcpdInterface{
 		Enable:  "1",
 		Range:   schema.Range{From: "192.168.1.100", To: "192.168.1.200"},
@@ -262,14 +264,23 @@ func TestConverter_DHCP(t *testing.T) {
 			{Number: "66", Type: "text", Value: "tftp.example.com"},
 		},
 	}
+	doc.Dhcpd.Items["opt1"] = schema.DhcpdInterface{
+		Enable:  "1",
+		Range:   schema.Range{From: "10.10.0.100", To: "10.10.0.200"},
+		Gateway: "10.10.0.1",
+	}
 
 	device, warnings, err := opnsense.ConvertDocument(doc)
 	require.NoError(t, err)
 	assert.Empty(t, warnings)
-	require.Len(t, device.DHCP, 1)
+	require.Len(t, device.DHCP, 2)
+
+	// Assert positional order so a regression in the sorted-keys idiom
+	// surfaces here rather than silently in downstream output.
+	assert.Equal(t, "lan", device.DHCP[0].Interface, "scopes should be sorted lexicographically")
+	assert.Equal(t, "opt1", device.DHCP[1].Interface, "scopes should be sorted lexicographically")
 
 	scope := device.DHCP[0]
-	assert.Equal(t, "lan", scope.Interface)
 	assert.True(t, scope.Enabled)
 	assert.Equal(t, "192.168.1.100", scope.Range.From)
 	assert.Equal(t, "192.168.1.200", scope.Range.To)

--- a/pkg/parser/opnsense/sortkeys_bench_test.go
+++ b/pkg/parser/opnsense/sortkeys_bench_test.go
@@ -29,7 +29,7 @@ func BenchmarkSortedMapKeys_Sorted(b *testing.B) {
 		b.Run(strconv.Itoa(size), func(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
-			for range b.N {
+			for b.Loop() {
 				for range slices.Sorted(maps.Keys(m)) { //nolint:revive // benchmark consumes the iterator
 				}
 			}
@@ -43,7 +43,7 @@ func BenchmarkSortedMapKeys_PreallocSort(b *testing.B) {
 		b.Run(strconv.Itoa(size), func(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
-			for range b.N {
+			for b.Loop() {
 				keys := make([]string, 0, len(m))
 				for k := range m {
 					keys = append(keys, k)

--- a/pkg/parser/opnsense/sortkeys_bench_test.go
+++ b/pkg/parser/opnsense/sortkeys_bench_test.go
@@ -2,10 +2,12 @@
 //
 // NATS-38 finding 4 proposes replacing slices.Sorted(maps.Keys(items))
 // with the single-allocation make([]K, 0, len(items)) + range +
-// slices.Sort pattern at three converter call sites. The ticket itself
+// slices.Sort pattern at the converter call sites. The ticket itself
 // flags this as marginal at typical map sizes; this bench is the
-// arbiter that decides whether to land it.
-package opnsense
+// arbiter that decided to land it across opnsense convertInterfaces,
+// opnsense convertDHCP, opnsense Kea reservation orphan check,
+// pfsense convertInterfaces, and pfsense convertDHCP.
+package opnsense_test
 
 import (
 	"fmt"
@@ -28,9 +30,9 @@ func BenchmarkSortedMapKeys_Sorted(b *testing.B) {
 		m := makeKeyMap(size)
 		b.Run(strconv.Itoa(size), func(b *testing.B) {
 			b.ReportAllocs()
-			b.ResetTimer()
 			for b.Loop() {
-				for range slices.Sorted(maps.Keys(m)) { //nolint:revive // benchmark consumes the iterator
+				//nolint:revive // benchmark consumes the iterator with no per-element work
+				for range slices.Sorted(maps.Keys(m)) {
 				}
 			}
 		})
@@ -42,14 +44,14 @@ func BenchmarkSortedMapKeys_PreallocSort(b *testing.B) {
 		m := makeKeyMap(size)
 		b.Run(strconv.Itoa(size), func(b *testing.B) {
 			b.ReportAllocs()
-			b.ResetTimer()
 			for b.Loop() {
 				keys := make([]string, 0, len(m))
 				for k := range m {
 					keys = append(keys, k)
 				}
 				slices.Sort(keys)
-				for range keys { //nolint:revive // benchmark consumes the slice
+				//nolint:revive // benchmark consumes the slice with no per-element work
+				for range keys {
 				}
 			}
 		})

--- a/pkg/parser/opnsense/sortkeys_bench_test.go
+++ b/pkg/parser/opnsense/sortkeys_bench_test.go
@@ -1,0 +1,57 @@
+// Focused micro-benchmark for the converter "sorted map keys" idiom.
+//
+// NATS-38 finding 4 proposes replacing slices.Sorted(maps.Keys(items))
+// with the single-allocation make([]K, 0, len(items)) + range +
+// slices.Sort pattern at three converter call sites. The ticket itself
+// flags this as marginal at typical map sizes; this bench is the
+// arbiter that decides whether to land it.
+package opnsense
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"strconv"
+	"testing"
+)
+
+func makeKeyMap(n int) map[string]int {
+	m := make(map[string]int, n)
+	for i := range n {
+		m[fmt.Sprintf("iface%03d", i)] = i
+	}
+	return m
+}
+
+func BenchmarkSortedMapKeys_Sorted(b *testing.B) {
+	for _, size := range []int{8, 32, 128} {
+		m := makeKeyMap(size)
+		b.Run(strconv.Itoa(size), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				for range slices.Sorted(maps.Keys(m)) { //nolint:revive // benchmark consumes the iterator
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkSortedMapKeys_PreallocSort(b *testing.B) {
+	for _, size := range []int{8, 32, 128} {
+		m := makeKeyMap(size)
+		b.Run(strconv.Itoa(size), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				keys := make([]string, 0, len(m))
+				for k := range m {
+					keys = append(keys, k)
+				}
+				slices.Sort(keys)
+				for range keys { //nolint:revive // benchmark consumes the slice
+				}
+			}
+		})
+	}
+}

--- a/pkg/parser/pfsense/converter_network.go
+++ b/pkg/parser/pfsense/converter_network.go
@@ -2,7 +2,6 @@ package pfsense
 
 import (
 	"fmt"
-	"maps"
 	"slices"
 
 	common "github.com/EvilBit-Labs/opnDossier/pkg/model"
@@ -17,8 +16,15 @@ func (c *converter) convertInterfaces(doc *pfsense.Document) []common.Interface 
 		return nil
 	}
 
+	// Single-allocation sorted-keys idiom; see opnsense convertInterfaces.
+	keys := make([]string, 0, len(items))
+	for k := range items {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+
 	result := make([]common.Interface, 0, len(items))
-	for _, key := range slices.Sorted(maps.Keys(items)) {
+	for _, key := range keys {
 		iface := items[key]
 		result = append(result, common.Interface{
 			Name:         key,

--- a/pkg/parser/pfsense/converter_services.go
+++ b/pkg/parser/pfsense/converter_services.go
@@ -2,7 +2,6 @@ package pfsense
 
 import (
 	"fmt"
-	"maps"
 	"slices"
 	"strings"
 
@@ -18,8 +17,15 @@ func (c *converter) convertDHCP(doc *pfsense.Document) []common.DHCPScope {
 		return nil
 	}
 
+	// Single-allocation sorted-keys idiom; see opnsense convertInterfaces.
+	keys := make([]string, 0, len(items))
+	for k := range items {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+
 	result := make([]common.DHCPScope, 0, len(items))
-	for _, key := range slices.Sorted(maps.Keys(items)) {
+	for _, key := range keys {
 		d := items[key]
 		scope := common.DHCPScope{
 			Interface:  key,

--- a/pkg/parser/pfsense/parser_test.go
+++ b/pkg/parser/pfsense/parser_test.go
@@ -444,6 +444,9 @@ func TestConverter_DHCP(t *testing.T) {
 	t.Parallel()
 
 	doc := pfsenseSchema.NewDocument()
+	// Two scopes are required to exercise the sorted-keys idiom in
+	// convertDHCP — a single-entry fixture would sort correctly under
+	// any algorithm and could not catch an ordering regression.
 	doc.Dhcpd.Items["lan"] = pfsenseSchema.DhcpdInterface{
 		Enable: opnsense.BoolFlag(true),
 		Range:  opnsense.Range{From: "192.168.1.100", To: "192.168.1.200"},
@@ -454,13 +457,21 @@ func TestConverter_DHCP(t *testing.T) {
 			{Number: "6", Type: "text", Value: "8.8.8.8"},
 		},
 	}
+	doc.Dhcpd.Items["opt1"] = pfsenseSchema.DhcpdInterface{
+		Enable: opnsense.BoolFlag(true),
+		Range:  opnsense.Range{From: "10.10.0.100", To: "10.10.0.200"},
+	}
 
 	device, _, err := pfsense.ConvertDocument(doc)
 	require.NoError(t, err)
-	require.Len(t, device.DHCP, 1)
+	require.Len(t, device.DHCP, 2)
+
+	// Assert positional order so a regression in the sorted-keys idiom
+	// surfaces here rather than silently in downstream output.
+	assert.Equal(t, "lan", device.DHCP[0].Interface, "scopes should be sorted lexicographically")
+	assert.Equal(t, "opt1", device.DHCP[1].Interface, "scopes should be sorted lexicographically")
 
 	scope := device.DHCP[0]
-	assert.Equal(t, "lan", scope.Interface)
 	assert.True(t, scope.Enabled)
 	assert.Equal(t, "192.168.1.100", scope.Range.From)
 	assert.Equal(t, "192.168.1.200", scope.Range.To)


### PR DESCRIPTION
## Summary

Cuts allocations in the firewall-row markdown table-building hot path. `BenchmarkFirewallRulesTable` (500-row sub-bench) drops **13,404 → 7,904 allocs/op (-41.0%)** on Apple M5; bytes drop 24%, time drops 37%. Existing tests pass unchanged so rendered output stays byte-identical.

Three production changes land:

- `EscapeTableContent` (`internal/converter/formatters/utils.go`) gains two fast paths — an unnamed-string type assertion and a `reflect.Kind == reflect.String` check for named string types like `FirewallRuleType`, `IPProtocol`, and `VIPMode`. Both skip the `fmt.Sprintf("%v", ...)` reflection boxing.
- `FormatInterfacesAsLinks` (`internal/converter/formatters/formatters.go`) replaces the `make([]string, ..) + per-link markdown.Link + strings.Join` body with a pre-grown `strings.Builder`. Output is byte-identical to the prior `[name](#name-interface)` form. The `nao1215/markdown` import is dropped from this file (still used elsewhere).
- Five converter sites move from `slices.Sorted(maps.Keys(items))` to a single-allocation `make + range + slices.Sort` idiom — opnsense `convertInterfaces`, opnsense `convertDHCP`, opnsense Kea reservation orphan check, pfsense `convertInterfaces`, pfsense `convertDHCP`. Microbench shows 7→1 to 11→1 allocs depending on map size (8/32/128 keys).

Two findings from the original Jira ticket were evaluated and **reverted** as bench-confirmed regressions, with the reasoning recorded inline so the experiments are not retried:

- Pre-sizing the per-severity `Findings` slices in `NewReport`. `make([]T, 0, N)` forces an N-element heap allocation; `make([]T, 0)` is the zero-allocation zero-cap form. Capacity hints regressed `BenchmarkNewReport` from 1 alloc/op + 288 B/op to 6 allocs/op + 14,688 B/op.
- Pre-sizing the statistics maps in `internal/analysis/statistics.go::newStatistics` via `len(cfg.Interfaces)`. `make(map[K]V, hint)` with hint ≥ 9 forces an immediate separate bucket-array allocation that the no-hint path avoids. The 100-fixture (10 interfaces) regressed by 1 alloc; the 500-fixture saw -3 allocs. Real-world configs sit in the 3-30 interface range where the regression dominates.

Two coverage gaps surfaced during review are filled here:

- DHCP and interface converter tests now use multi-key fixtures and assert positional sort order so a future regression in the sorted-keys idiom surfaces as a test failure rather than silently in downstream output.
- `TestFormatInterfacesAsLinks` gains a mixed-case multi-element case to pin the byte-identity invariant after the strings.Builder rewrite. `TestEscapeTableContent` gains named-string-type cases.
- `BenchmarkFirewallRulesTable_InterfaceCount` covers the empty/single/multi-interface paths the main bench under-covered. `BenchmarkEscapeTableContent` covers the four dispatch paths (unnamed string, named string via reflect, fmt.Sprintf fallback, nil).

Resolves [NATS-38](https://evilbitlabs.atlassian.net/browse/NATS-38).

## Reproducing the bench numbers

The merge gate is BenchmarkFirewallRulesTable's 500-row sub-bench. The other benches surface either the negative results or the fast-path savings in isolation.

\`\`\`
# Headline merge gate (>=30% allocs/op reduction target)
go test -bench BenchmarkFirewallRulesTable\$ -benchmem -count=10 -run=^\$ -benchtime=200ms ./internal/converter/builder/...

# Interface-count fan-out coverage
go test -bench BenchmarkFirewallRulesTable_InterfaceCount -benchmem -count=10 -run=^\$ -benchtime=200ms ./internal/converter/builder/...

# EscapeTableContent dispatch-path costs
go test -bench BenchmarkEscapeTableContent -benchmem -count=10 -run=^\$ -benchtime=200ms ./internal/converter/formatters/...

# Sorted-keys idiom: slices.Sorted vs make+range+slices.Sort
go test -bench BenchmarkSortedMapKeys -benchmem -count=10 -run=^\$ -benchtime=200ms ./pkg/parser/opnsense/...

# Negative-result regression guards (pin the empty/populated baselines)
go test -bench BenchmarkNewReport -benchmem -count=5 -run=^\$ -benchtime=200ms ./internal/processor/
go test -bench BenchmarkComputeStatistics -benchmem -count=5 -run=^\$ -benchtime=200ms ./internal/analysis/
\`\`\`

## Verification

- \`just ci-check\` clean.
- \`just test-race ./internal/...\` clean — no concurrency regressions.
- Existing builder, formatter, converter, and analysis tests pass unchanged.

## Test plan

- [x] \`just ci-check\` passes locally
- [x] \`just test-race\` passes locally
- [x] \`BenchmarkFirewallRulesTable/500\` post-change <= 9,383 allocs/op (R2 acceptance)
- [x] \`BenchmarkFirewallRulesTable_InterfaceCount\` covers ifaces={0,1,4}
- [x] \`TestFormatInterfacesAsLinks\` covers mixed-case multi-element
- [x] \`TestEscapeTableContent\` covers named string types
- [x] opnsense + pfsense \`TestConverter_DHCP\` use multi-key fixtures with positional assertions
- [x] opnsense \`TestConverter_Interfaces\` asserts positional order

## AI Disclosure

Used Claude Code (Claude Opus 4.7 (1M Context)) for the implementation, bench-driven evaluation of each finding, multi-agent code review, and review-feedback fixes. All code reviewed by the author; numbers reproduced locally with the commands above. See [AI_POLICY.md](../blob/main/AI_POLICY.md).

[NATS-38]: https://evilbitlabs.atlassian.net/browse/NATS-38?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ