### PR TITLE
ci(mergify): drop codecov/patch from merge gate

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -41,7 +41,6 @@ queue_rules:
       - "check-success = Test (windows-latest, stable)"
       - check-success = Integration Tests
       - check-success = Coverage
-      - check-success = codecov/patch
 
   # ─────────────────────────────────────────────────────────────────────────
   # 4. default — manually enqueued by maintainers, full CI
@@ -57,7 +56,6 @@ queue_rules:
       - "check-success = Test (windows-latest, stable)"
       - check-success = Integration Tests
       - check-success = Coverage
-      - check-success = codecov/patch
 
 pull_request_rules:
   # ─────────────────────────────────────────────────────────────────────────
@@ -133,7 +131,6 @@ merge_protections:
       - "check-success = Test (windows-latest, stable)"
       - check-success = Integration Tests
       - check-success = Coverage
-      - check-success = codecov/patch
 
   # ─────────────────────────────────────────────────────────────────────────
   # 3. Lint-only for bots with workflow-only changes


### PR DESCRIPTION
## Summary

Removes \`codecov/patch\` from Mergify's merge_conditions and merge_protections.

The Codecov patch-coverage commit status does not always post on a PR head — when it doesn't, Mergify Merge Protections sits pending indefinitely even after every other CI check has finished. Observed on PR #604.

The GitHub Actions \`Coverage\` job is still gated in the same merge_conditions blocks, so coverage requirements are unchanged. Only the unreliable third-party signal is dropped.

## Test plan

- [x] \`grep codecov .mergify.yml\` returns nothing
- [x] \`Coverage\` check still listed in all three merge_conditions blocks
- [ ] Next merge-gated PR shows Mergify Merge Protections completing without waiting for codecov/patch