### PR TITLE
perf(converter): NATS-37 memoize statistics and analysis for multi-format exports

### DIFF
--- a/internal/converter/benchmark_test.go
+++ b/internal/converter/benchmark_test.go
@@ -47,6 +47,113 @@ func BenchmarkMarkdownConverter_ToMarkdown(b *testing.B) {
 	}
 }
 
+// BenchmarkMultiFormatExport measures the per-format cost of preparing a single
+// device for multiple output formats (markdown + JSON + YAML, sequential). The
+// "PerFormatRecompute" variant is the pre-NATS-37 behavior where each format
+// generation re-runs analysis. The "PreEnrichOnce" variant calls
+// EnrichForExport before the format loop so the expensive analysis runs once
+// per device. The delta between the two is the speedup the ticket targets.
+//
+// The benchmark uses both a medium config (sample.config.2.xml, ~17KB) and the
+// large config (sample.config.6.xml, ~119KB) so reviewers can see how the
+// memoization win scales with input size — small configs amortize too quickly
+// for the difference to be measurable.
+func BenchmarkMultiFormatExport(b *testing.B) {
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"Medium", filepath.Join("..", "..", "testdata", "sample.config.2.xml")},
+		{"Large", filepath.Join("..", "..", "testdata", "sample.config.6.xml")},
+	}
+
+	formats := []Format{FormatMarkdown, FormatJSON, FormatYAML}
+
+	for _, tc := range cases {
+		xmlData, err := os.ReadFile(tc.path)
+		if err != nil {
+			b.Fatalf("Failed to read %s: %v", tc.path, err)
+		}
+		factory := parser.NewFactory(cfgparser.NewXMLParser())
+		device, _, err := factory.CreateDevice(
+			context.Background(),
+			strings.NewReader(string(xmlData)),
+			common.DeviceTypeUnknown,
+			false,
+		)
+		if err != nil {
+			b.Fatalf("XML parsing failed for %s: %v", tc.path, err)
+		}
+
+		// Precondition: the parsed device must start with nil enrichment fields
+		// so PerFormatRecompute genuinely re-runs analysis on each Generate call.
+		// If a future parser change pre-populates these, both sub-benchmarks
+		// would silently degenerate to the same workload and the speedup signal
+		// would vanish without a test failure.
+		if device.Statistics != nil || device.Analysis != nil {
+			b.Fatalf("benchmark precondition violated: parsed device must have nil Statistics/Analysis")
+		}
+
+		gen, err := NewMarkdownGenerator(nil, Options{})
+		if err != nil {
+			b.Fatalf("NewMarkdownGenerator failed: %v", err)
+		}
+		ctx := context.Background()
+
+		b.Run(tc.name+"/PerFormatRecompute", runMultiFormatGenerate(ctx, gen, device, formats, false))
+		b.Run(tc.name+"/PreEnrichOnce", runMultiFormatGenerate(ctx, gen, device, formats, true))
+
+		// Bare prepareForExport sub-benchmarks isolate the analysis cost from
+		// markdown rendering and JSON/YAML marshaling, so the memoization
+		// savings are visible without serialization noise diluting the signal.
+		// The headline `PerFormatRecompute` / `PreEnrichOnce` benchmarks above
+		// model the realistic multi-format CLI workload; these two model the
+		// per-format prep work alone.
+		b.Run(tc.name+"/PrepareForExportOnly_Recompute", runMultiFormatPrepare(device, formats, false))
+		b.Run(tc.name+"/PrepareForExportOnly_PreEnrich", runMultiFormatPrepare(device, formats, true))
+	}
+}
+
+func runMultiFormatGenerate(
+	ctx context.Context,
+	gen Generator,
+	device *common.CommonDevice,
+	formats []Format,
+	preEnrich bool,
+) func(*testing.B) {
+	return func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			d := *device
+			if preEnrich {
+				EnrichForExport(&d)
+			}
+			for _, f := range formats {
+				opts := DefaultOptions()
+				opts.Format = f
+				if _, err := gen.Generate(ctx, &d, opts); err != nil {
+					b.Fatalf("Generate %s failed: %v", f, err)
+				}
+			}
+		}
+	}
+}
+
+func runMultiFormatPrepare(device *common.CommonDevice, formats []Format, preEnrich bool) func(*testing.B) {
+	return func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			d := *device
+			if preEnrich {
+				EnrichForExport(&d)
+			}
+			for range formats {
+				_ = prepareForExport(&d, false)
+			}
+		}
+	}
+}
+
 func BenchmarkMarkdownConverter_ToMarkdown_Large(b *testing.B) {
 	// Use the larger sample config for stress testing
 	xmlPath := filepath.Join("..", "..", "testdata", "sample.config.2.xml")

--- a/internal/converter/benchmark_test.go
+++ b/internal/converter/benchmark_test.go
@@ -100,17 +100,16 @@ func BenchmarkMultiFormatExport(b *testing.B) {
 		}
 		ctx := context.Background()
 
-		b.Run(tc.name+"/PerFormatRecompute", runMultiFormatGenerate(ctx, gen, device, formats, false))
-		b.Run(tc.name+"/PreEnrichOnce", runMultiFormatGenerate(ctx, gen, device, formats, true))
+		// Headline sub-benchmarks: realistic multi-format CLI workload, including
+		// markdown rendering and JSON/YAML marshaling.
+		b.Run(tc.name+"/Generate_Recompute", runMultiFormatGenerate(ctx, gen, device, formats, false))
+		b.Run(tc.name+"/Generate_Enriched", runMultiFormatGenerate(ctx, gen, device, formats, true))
 
-		// Bare prepareForExport sub-benchmarks isolate the analysis cost from
-		// markdown rendering and JSON/YAML marshaling, so the memoization
-		// savings are visible without serialization noise diluting the signal.
-		// The headline `PerFormatRecompute` / `PreEnrichOnce` benchmarks above
-		// model the realistic multi-format CLI workload; these two model the
-		// per-format prep work alone.
-		b.Run(tc.name+"/PrepareForExportOnly_Recompute", runMultiFormatPrepare(device, formats, false))
-		b.Run(tc.name+"/PrepareForExportOnly_PreEnrich", runMultiFormatPrepare(device, formats, true))
+		// Bare prepareForExport sub-benchmarks: isolate the analysis cost from
+		// rendering and marshaling, so the memoization savings are visible
+		// without serialization noise diluting the signal.
+		b.Run(tc.name+"/Prepare_Recompute", runMultiFormatPrepare(device, formats, false))
+		b.Run(tc.name+"/Prepare_Enriched", runMultiFormatPrepare(device, formats, true))
 	}
 }
 

--- a/internal/converter/benchmark_test.go
+++ b/internal/converter/benchmark_test.go
@@ -48,11 +48,15 @@ func BenchmarkMarkdownConverter_ToMarkdown(b *testing.B) {
 }
 
 // BenchmarkMultiFormatExport measures the per-format cost of preparing a single
-// device for multiple output formats (markdown + JSON + YAML, sequential). The
-// "PerFormatRecompute" variant is the pre-NATS-37 behavior where each format
-// generation re-runs analysis. The "PreEnrichOnce" variant calls
-// EnrichForExport before the format loop so the expensive analysis runs once
-// per device. The delta between the two is the speedup the ticket targets.
+// device for multiple output formats (markdown + JSON + YAML, sequential). Two
+// variant pairs run side-by-side:
+//
+//   - Generate_Recompute / Generate_Enriched: realistic CLI workload —
+//     full Generate() per format including markdown rendering and JSON/YAML
+//     marshaling. _Recompute is the pre-memoization baseline (no
+//     EnrichForExport); _Enriched calls EnrichForExport before the format loop.
+//   - Prepare_Recompute / Prepare_Enriched: bare prepareForExport calls only,
+//     isolating the analysis cost from rendering and serialization noise.
 //
 // The benchmark uses both a medium config (sample.config.2.xml, ~17KB) and the
 // large config (sample.config.6.xml, ~119KB) so reviewers can see how the
@@ -86,10 +90,10 @@ func BenchmarkMultiFormatExport(b *testing.B) {
 		}
 
 		// Precondition: the parsed device must start with nil enrichment fields
-		// so PerFormatRecompute genuinely re-runs analysis on each Generate call.
-		// If a future parser change pre-populates these, both sub-benchmarks
-		// would silently degenerate to the same workload and the speedup signal
-		// would vanish without a test failure.
+		// so the _Recompute variants genuinely re-run analysis on each call. If
+		// a future parser change pre-populates these, both _Recompute and
+		// _Enriched sub-benchmarks would silently degenerate to the same
+		// workload and the speedup signal would vanish without a test failure.
 		if device.Statistics != nil || device.Analysis != nil {
 			b.Fatalf("benchmark precondition violated: parsed device must have nil Statistics/Analysis")
 		}

--- a/internal/converter/benchmark_test.go
+++ b/internal/converter/benchmark_test.go
@@ -112,8 +112,12 @@ func BenchmarkMultiFormatExport(b *testing.B) {
 		// Bare prepareForExport sub-benchmarks: isolate the analysis cost from
 		// rendering and marshaling, so the memoization savings are visible
 		// without serialization noise diluting the signal.
-		b.Run(tc.name+"/Prepare_Recompute", runMultiFormatPrepare(device, formats, false))
-		b.Run(tc.name+"/Prepare_Enriched", runMultiFormatPrepare(device, formats, true))
+		b.Run(tc.name+"/Prepare_Recompute", runMultiFormatPrepare(device, formats, false, false))
+		b.Run(tc.name+"/Prepare_Enriched", runMultiFormatPrepare(device, formats, true, false))
+		// Redact-path variant on the memoized prepare: surfaces the clone-on-write
+		// cost in redactStatisticsServiceDetails (Statistics + ServiceDetails +
+		// Details map) on the production audit/export path.
+		b.Run(tc.name+"/Prepare_Enriched_Redact", runMultiFormatPrepare(device, formats, true, true))
 	}
 }
 
@@ -142,7 +146,7 @@ func runMultiFormatGenerate(
 	}
 }
 
-func runMultiFormatPrepare(device *common.CommonDevice, formats []Format, preEnrich bool) func(*testing.B) {
+func runMultiFormatPrepare(device *common.CommonDevice, formats []Format, preEnrich, redact bool) func(*testing.B) {
 	return func(b *testing.B) {
 		b.ReportAllocs()
 		for b.Loop() {
@@ -151,7 +155,7 @@ func runMultiFormatPrepare(device *common.CommonDevice, formats []Format, preEnr
 				EnrichForExport(&d)
 			}
 			for range formats {
-				_ = prepareForExport(&d, false)
+				_ = prepareForExport(&d, redact)
 			}
 		}
 	}

--- a/internal/converter/enrichment.go
+++ b/internal/converter/enrichment.go
@@ -26,11 +26,86 @@ func computePerformanceMetrics(stats *common.Statistics) *common.PerformanceMetr
 // redactedValue is the placeholder for sensitive fields in exported output.
 const redactedValue = "[REDACTED]"
 
+// EnrichForExport populates the read-only enrichment fields on data in place
+// when they are nil: DeviceType (defaulting to OPNsense), Statistics, Analysis,
+// SecurityAssessment, and PerformanceMetrics. ComplianceResults is left alone —
+// it is populated externally by the audit handler.
+//
+// EnrichForExport is the explicit memoization entry point for callers preparing
+// the same device for multiple format exports (e.g. JSON + YAML + Markdown).
+// computeStatistics and computeAnalysis are O(n) over interfaces, rules, and
+// services and dominate per-format export time; calling EnrichForExport once
+// before the format loop avoids recomputing them per format. Subsequent calls
+// to prepareForExport observe the populated fields via its shallow copy and
+// skip the heavy work.
+//
+// SECURITY: EnrichForExport does not redact sensitive fields. The resulting
+// *CommonDevice carries plaintext secrets — most notably the SNMP community
+// string in Statistics.ServiceDetails — because analysis.ComputeStatistics
+// observes unredacted input by design (presence checks must see real values).
+// Callers MUST NOT marshal or log the device directly after EnrichForExport.
+// Always pass the device through prepareForExport (or a downstream Generator
+// that calls prepareForExport) so the redact branch can produce a clone with
+// the sensitive fields stripped.
+//
+// Redaction is per-export and is applied by prepareForExport on its shallow
+// copy. The Statistics pointer produced here is reused by every subsequent
+// prepareForExport call — the redact-path clones the Statistics struct before
+// mutating ServiceDetails so a pre-enriched device is safe to share across
+// redact=true and redact=false callers.
+//
+// CACHE INVALIDATION: EnrichForExport memoizes Statistics and Analysis as a
+// snapshot of the device at call time. If the caller mutates a field that
+// feeds those computations (e.g., device.SNMP.ROCommunity, FirewallRules,
+// Interfaces) after calling EnrichForExport, the cached values go stale and
+// subsequent exports will reflect the pre-mutation state. Re-call
+// EnrichForExport (after first clearing the affected enrichment field) when
+// the underlying configuration changes between exports.
+//
+// EnrichForExport is not safe for concurrent use on the same *CommonDevice.
+// Callers preparing one device for parallel format exports must call
+// EnrichForExport once before fanning out.
+//
+// NOTE: analysis.ComputeStatistics and analysis.ComputeAnalysis intentionally
+// receive the unredacted data so that presence checks (e.g., "is SNMP
+// configured?") see real values.
+func EnrichForExport(data *common.CommonDevice) {
+	if data == nil {
+		return
+	}
+	enrich(data)
+}
+
+// enrich populates the read-only enrichment fields on dst in place when nil.
+// Callers must invoke enrich before any redaction so analysis.ComputeStatistics
+// and analysis.ComputeAnalysis observe unredacted input.
+func enrich(dst *common.CommonDevice) {
+	if dst.DeviceType == "" {
+		dst.DeviceType = common.DeviceTypeOPNsense
+	}
+	if dst.Statistics == nil {
+		dst.Statistics = analysis.ComputeStatistics(dst)
+	}
+	if dst.Analysis == nil {
+		dst.Analysis = analysis.ComputeAnalysis(dst)
+	}
+	if dst.SecurityAssessment == nil {
+		dst.SecurityAssessment = computeSecurityAssessment(dst.Statistics)
+	}
+	if dst.PerformanceMetrics == nil {
+		dst.PerformanceMetrics = computePerformanceMetrics(dst.Statistics)
+	}
+}
+
 // prepareForExport returns a shallow copy of the device with default DeviceType,
 // Statistics, Analysis, SecurityAssessment, and PerformanceMetrics populated when absent.
 // When redact is true, sensitive fields (passwords, private keys, API secrets, SNMP
 // community strings, WireGuard PSKs, DHCPv6 authentication secrets) are replaced with
 // [REDACTED]. When redact is false, sensitive fields are passed through as-is.
+//
+// prepareForExport does not mutate data. Callers that prepare the same device for
+// multiple format exports should call EnrichForExport first to memoize the
+// expensive Statistics and Analysis computations across calls.
 //
 // NOTE: analysis.ComputeStatistics and analysis.ComputeAnalysis intentionally receive
 // the original unredacted data so that presence checks (e.g., "is SNMP configured?")
@@ -38,32 +113,13 @@ const redactedValue = "[REDACTED]"
 func prepareForExport(data *common.CommonDevice, redact bool) *common.CommonDevice {
 	cp := *data
 
-	if cp.DeviceType == "" {
-		cp.DeviceType = common.DeviceTypeOPNsense
-	}
+	// enrich must run before redaction so analysis.ComputeStatistics and
+	// analysis.ComputeAnalysis observe unredacted input — see enrich godoc.
+	enrich(&cp)
 
 	if redact {
 		redactSensitiveFields(&cp)
-	}
-
-	if cp.Statistics == nil {
-		cp.Statistics = analysis.ComputeStatistics(data)
-	}
-
-	if redact {
-		redactStatisticsServiceDetails(cp.Statistics)
-	}
-
-	if cp.Analysis == nil {
-		cp.Analysis = analysis.ComputeAnalysis(data)
-	}
-
-	if cp.SecurityAssessment == nil {
-		cp.SecurityAssessment = computeSecurityAssessment(cp.Statistics)
-	}
-
-	if cp.PerformanceMetrics == nil {
-		cp.PerformanceMetrics = computePerformanceMetrics(cp.Statistics)
+		cp.Statistics = redactStatisticsServiceDetails(cp.Statistics)
 	}
 
 	// ComplianceResults is populated externally by the audit handler;
@@ -177,22 +233,47 @@ func redactDHCPv6Secrets(cp *common.CommonDevice) {
 	}
 }
 
-// redactStatisticsServiceDetails replaces sensitive values in Statistics.ServiceDetails
-// with the redaction marker. This is needed because analysis.ComputeStatistics intentionally
-// receives the original unredacted data for accurate presence detection, but the
-// resulting ServiceDetails may contain sensitive values (e.g., SNMP community strings).
-func redactStatisticsServiceDetails(stats *common.Statistics) {
+// redactStatisticsServiceDetails returns a Statistics whose sensitive
+// ServiceDetails values are replaced with the redaction marker. The input is
+// not mutated: when redaction is required the function clones the Statistics
+// struct, the ServiceDetails slice, and the affected per-element Details map.
+// When no SNMP community redaction is needed, the input pointer is returned
+// unchanged. This non-mutating contract lets EnrichForExport memoize a single
+// Statistics across mixed redact=true and redact=false callers without leaking
+// redacted values into the caller's data.
+//
+// Every matching SNMP community entry is redacted, not just the first.
+// analysis.ComputeStatistics emits a single SNMP entry today, but a future
+// schema change (SNMPv3, separate read/write communities, multi-instance
+// agents) could surface multiple — leaving any of them in cleartext would be a
+// regression vs. the pre-NATS-37 in-place mutator.
+func redactStatisticsServiceDetails(stats *common.Statistics) *common.Statistics {
 	if stats == nil {
-		return
+		return nil
 	}
 
+	var matches []int
 	for i := range stats.ServiceDetails {
-		if stats.ServiceDetails[i].Name == analysis.ServiceNameSNMP && stats.ServiceDetails[i].Details != nil {
-			if _, ok := stats.ServiceDetails[i].Details["community"]; ok {
-				// Deep-copy the map to avoid mutating shared state.
-				stats.ServiceDetails[i].Details = maps.Clone(stats.ServiceDetails[i].Details)
-				stats.ServiceDetails[i].Details["community"] = redactedValue
-			}
+		if stats.ServiceDetails[i].Name != analysis.ServiceNameSNMP {
+			continue
+		}
+		if stats.ServiceDetails[i].Details == nil {
+			continue
+		}
+		if _, ok := stats.ServiceDetails[i].Details["community"]; ok {
+			matches = append(matches, i)
 		}
 	}
+	if len(matches) == 0 {
+		return stats
+	}
+
+	out := *stats
+	out.ServiceDetails = slices.Clone(stats.ServiceDetails)
+	for _, idx := range matches {
+		out.ServiceDetails[idx].Details = maps.Clone(stats.ServiceDetails[idx].Details)
+		out.ServiceDetails[idx].Details["community"] = redactedValue
+	}
+
+	return &out
 }

--- a/internal/converter/enrichment.go
+++ b/internal/converter/enrichment.go
@@ -68,8 +68,13 @@ var snmpSensitiveDetailKeys = []string{"community"}
 // feeds those computations (e.g., device.SNMP.ROCommunity, FirewallRules,
 // Interfaces) after calling EnrichForExport, the cached values go stale and
 // subsequent exports will reflect the pre-mutation state. Re-call
-// EnrichForExport (after first clearing the affected enrichment field) when
-// the underlying configuration changes between exports.
+// EnrichForExport after clearing the affected enrichment field when the
+// underlying configuration changes between exports.
+//
+// Clearing Statistics is sufficient to invalidate the Statistics-derived
+// fields too: SecurityAssessment and PerformanceMetrics are recomputed
+// together with Statistics. To refresh Analysis, clear Analysis. The two
+// caches are independent.
 //
 // EnrichForExport is not safe for concurrent use on the same *CommonDevice.
 // Callers preparing one device for parallel format exports must call
@@ -95,21 +100,35 @@ func EnrichForExport(data *common.CommonDevice) {
 // and analysis.ComputeAnalysis observe unredacted input. Callers must also
 // guarantee dst is non-nil; nil-checking is the public-API caller's
 // responsibility.
+//
+// SecurityAssessment and PerformanceMetrics are derived from Statistics. When
+// Statistics is (re)computed, both derived fields are also (re)computed so a
+// partial cache invalidation — caller clears only Statistics to refresh after
+// a config change — does not leave stale derived metrics tied to a Statistics
+// that no longer exists.
 func enrich(dst *common.CommonDevice) {
 	if dst.DeviceType == "" {
 		dst.DeviceType = common.DeviceTypeOPNsense
 	}
 	if dst.Statistics == nil {
 		dst.Statistics = analysis.ComputeStatistics(dst)
+		// Refresh derived fields together with Statistics. Existing values are
+		// intentionally overwritten — they were derived from a Statistics that
+		// has just been discarded.
+		dst.SecurityAssessment = computeSecurityAssessment(dst.Statistics)
+		dst.PerformanceMetrics = computePerformanceMetrics(dst.Statistics)
+	} else {
+		// Statistics preserved; populate derived fields when absent so callers
+		// who pre-populate Statistics alone still get a complete enrichment.
+		if dst.SecurityAssessment == nil {
+			dst.SecurityAssessment = computeSecurityAssessment(dst.Statistics)
+		}
+		if dst.PerformanceMetrics == nil {
+			dst.PerformanceMetrics = computePerformanceMetrics(dst.Statistics)
+		}
 	}
 	if dst.Analysis == nil {
 		dst.Analysis = analysis.ComputeAnalysis(dst)
-	}
-	if dst.SecurityAssessment == nil {
-		dst.SecurityAssessment = computeSecurityAssessment(dst.Statistics)
-	}
-	if dst.PerformanceMetrics == nil {
-		dst.PerformanceMetrics = computePerformanceMetrics(dst.Statistics)
 	}
 }
 

--- a/internal/converter/enrichment.go
+++ b/internal/converter/enrichment.go
@@ -26,6 +26,15 @@ func computePerformanceMetrics(stats *common.Statistics) *common.PerformanceMetr
 // redactedValue is the placeholder for sensitive fields in exported output.
 const redactedValue = "[REDACTED]"
 
+// snmpSensitiveDetailKeys lists the keys in Statistics.ServiceDetails[].Details
+// (for the SNMP service entry) whose values must be redacted on export.
+// Adding a new sensitive key — for example, an SNMPv3 authentication password
+// surfaced by a future analysis writer — is a one-line append here, not a
+// rewrite of the redaction loop in redactStatisticsServiceDetails.
+//
+//nolint:gochecknoglobals // immutable allowlist; mutation would be a security regression
+var snmpSensitiveDetailKeys = []string{"community"}
+
 // EnrichForExport populates the read-only enrichment fields on data in place
 // when they are nil: DeviceType (defaulting to OPNsense), Statistics, Analysis,
 // SecurityAssessment, and PerformanceMetrics. ComplianceResults is left alone —
@@ -79,6 +88,12 @@ func EnrichForExport(data *common.CommonDevice) {
 // enrich populates the read-only enrichment fields on dst in place when nil.
 // Callers must invoke enrich before any redaction so analysis.ComputeStatistics
 // and analysis.ComputeAnalysis observe unredacted input.
+//
+// Two callers, by design: EnrichForExport applies enrich to the caller's
+// device after a public-API nil guard, and prepareForExport applies it to its
+// shallow copy, where dst is the address of a value-copied struct and is
+// never nil. Keeping the populate logic in one place avoids drift between
+// the public memoization entry point and the per-export shallow-copy path.
 func enrich(dst *common.CommonDevice) {
 	if dst.DeviceType == "" {
 		dst.DeviceType = common.DeviceTypeOPNsense
@@ -237,16 +252,18 @@ func redactDHCPv6Secrets(cp *common.CommonDevice) {
 // ServiceDetails values are replaced with the redaction marker. The input is
 // not mutated: when redaction is required the function clones the Statistics
 // struct, the ServiceDetails slice, and the affected per-element Details map.
-// When no SNMP community redaction is needed, the input pointer is returned
+// When no SNMP entry carries any sensitive key, the input pointer is returned
 // unchanged. This non-mutating contract lets EnrichForExport memoize a single
 // Statistics across mixed redact=true and redact=false callers without leaking
 // redacted values into the caller's data.
 //
-// Every matching SNMP community entry is redacted, not just the first.
-// analysis.ComputeStatistics emits a single SNMP entry today, but a future
-// schema change (SNMPv3, separate read/write communities, multi-instance
-// agents) could surface multiple — leaving any of them in cleartext would be a
-// regression vs. the pre-NATS-37 in-place mutator.
+// Every matching SNMP entry is redacted (not just the first), and every key
+// in snmpSensitiveDetailKeys is redacted on each match.
+// analysis.ComputeStatistics emits a single SNMP entry with a single sensitive
+// key today, but a future schema change — SNMPv3 with both community and auth
+// password, separate read/write communities, multi-instance agents — could
+// surface multiple. Leaving any of them in cleartext would be a security
+// regression.
 func redactStatisticsServiceDetails(stats *common.Statistics) *common.Statistics {
 	if stats == nil {
 		return nil
@@ -260,7 +277,7 @@ func redactStatisticsServiceDetails(stats *common.Statistics) *common.Statistics
 		if stats.ServiceDetails[i].Details == nil {
 			continue
 		}
-		if _, ok := stats.ServiceDetails[i].Details["community"]; ok {
+		if hasSensitiveSNMPKey(stats.ServiceDetails[i].Details) {
 			matches = append(matches, i)
 		}
 	}
@@ -272,8 +289,21 @@ func redactStatisticsServiceDetails(stats *common.Statistics) *common.Statistics
 	out.ServiceDetails = slices.Clone(stats.ServiceDetails)
 	for _, idx := range matches {
 		out.ServiceDetails[idx].Details = maps.Clone(stats.ServiceDetails[idx].Details)
-		out.ServiceDetails[idx].Details["community"] = redactedValue
+		for _, key := range snmpSensitiveDetailKeys {
+			if _, ok := out.ServiceDetails[idx].Details[key]; ok {
+				out.ServiceDetails[idx].Details[key] = redactedValue
+			}
+		}
 	}
 
 	return &out
+}
+
+func hasSensitiveSNMPKey(details map[string]string) bool {
+	for _, key := range snmpSensitiveDetailKeys {
+		if _, ok := details[key]; ok {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/converter/enrichment.go
+++ b/internal/converter/enrichment.go
@@ -42,11 +42,11 @@ var snmpSensitiveDetailKeys = []string{"community"}
 //
 // EnrichForExport is the explicit memoization entry point for callers preparing
 // the same device for multiple format exports (e.g. JSON + YAML + Markdown).
-// computeStatistics and computeAnalysis are O(n) over interfaces, rules, and
-// services and dominate per-format export time; calling EnrichForExport once
-// before the format loop avoids recomputing them per format. Subsequent calls
-// to prepareForExport observe the populated fields via its shallow copy and
-// skip the heavy work.
+// analysis.ComputeStatistics and analysis.ComputeAnalysis are linear-or-worse
+// in the number of interfaces, rules, and services and dominate per-format
+// export time; calling EnrichForExport once before the format loop avoids
+// recomputing them per format. Subsequent prepareForExport calls reuse the
+// populated fields and skip the heavy work.
 //
 // SECURITY: EnrichForExport does not redact sensitive fields. The resulting
 // *CommonDevice carries plaintext secrets — most notably the SNMP community
@@ -75,6 +75,11 @@ var snmpSensitiveDetailKeys = []string{"community"}
 // Callers preparing one device for parallel format exports must call
 // EnrichForExport once before fanning out.
 //
+// EnrichForExport on a nil *CommonDevice is a documented no-op. Note that
+// the downstream prepareForExport will still panic on nil; callers must guard
+// nil at their own boundary (the JSONConverter / YAMLConverter wrappers and
+// HybridGenerator.Generate already do).
+//
 // NOTE: analysis.ComputeStatistics and analysis.ComputeAnalysis intentionally
 // receive the unredacted data so that presence checks (e.g., "is SNMP
 // configured?") see real values.
@@ -87,13 +92,9 @@ func EnrichForExport(data *common.CommonDevice) {
 
 // enrich populates the read-only enrichment fields on dst in place when nil.
 // Callers must invoke enrich before any redaction so analysis.ComputeStatistics
-// and analysis.ComputeAnalysis observe unredacted input.
-//
-// Two callers, by design: EnrichForExport applies enrich to the caller's
-// device after a public-API nil guard, and prepareForExport applies it to its
-// shallow copy, where dst is the address of a value-copied struct and is
-// never nil. Keeping the populate logic in one place avoids drift between
-// the public memoization entry point and the per-export shallow-copy path.
+// and analysis.ComputeAnalysis observe unredacted input. Callers must also
+// guarantee dst is non-nil; nil-checking is the public-API caller's
+// responsibility.
 func enrich(dst *common.CommonDevice) {
 	if dst.DeviceType == "" {
 		dst.DeviceType = common.DeviceTypeOPNsense
@@ -290,7 +291,13 @@ func redactStatisticsServiceDetails(stats *common.Statistics) *common.Statistics
 	for _, idx := range matches {
 		out.ServiceDetails[idx].Details = maps.Clone(stats.ServiceDetails[idx].Details)
 		for _, key := range snmpSensitiveDetailKeys {
-			if _, ok := out.ServiceDetails[idx].Details[key]; ok {
+			// Match the value-aware guard used by every other redactor in this
+			// file (cert/CA private keys, API key secrets, WireGuard PSKs,
+			// DHCPv6 secrets, HA password, SNMP ROCommunity): only replace when
+			// the value is actually present and non-empty. Stops empty-string
+			// placeholders from being flipped to "[REDACTED]", which would shift
+			// the semantic meaning a downstream consumer reads from the field.
+			if v, ok := out.ServiceDetails[idx].Details[key]; ok && v != "" {
 				out.ServiceDetails[idx].Details[key] = redactedValue
 			}
 		}
@@ -301,7 +308,7 @@ func redactStatisticsServiceDetails(stats *common.Statistics) *common.Statistics
 
 func hasSensitiveSNMPKey(details map[string]string) bool {
 	for _, key := range snmpSensitiveDetailKeys {
-		if _, ok := details[key]; ok {
+		if v, ok := details[key]; ok && v != "" {
 			return true
 		}
 	}

--- a/internal/converter/enrichment_test.go
+++ b/internal/converter/enrichment_test.go
@@ -777,32 +777,51 @@ func TestEnrichForExport_NilDeviceIsSafe(t *testing.T) {
 	})
 }
 
-func TestEnrichForExport_FanOutAcrossDevicesIsRaceClean(t *testing.T) {
-	// EnrichForExport's documented contract is "not safe for concurrent use on
-	// the same *CommonDevice", which implicitly says the *supported* pattern is
-	// fanning out across distinct devices in parallel — each goroutine owning
-	// its own *CommonDevice. Pin that with a -race regression: if a future
-	// refactor introduces hidden shared state inside enrich (e.g., a package
-	// cache), `go test -race` will catch it via this test.
-	//
-	// 3-reviewer cross-corroboration (correctness, security, adversarial)
-	// promoted this to anchor 100.
+func TestEnrichForExport_FanOutFromSingleEnrichedDeviceIsRaceClean(t *testing.T) {
+	// EnrichForExport's documented supported pattern is "one device, enrich
+	// once, fan out exports": a caller invokes EnrichForExport on a *CommonDevice,
+	// then dispatches concurrent prepareForExport calls that each consume the
+	// cached Statistics/Analysis pointers. This test pins that pattern under
+	// `go test -race`. If a future refactor starts mutating the cached
+	// Statistics from prepareForExport (e.g., the redact-path drops its
+	// clone-on-write), the race detector flags the concurrent reads against
+	// the fan-out write.
 	t.Parallel()
+
+	device := &common.CommonDevice{
+		SNMP: common.SNMPConfig{
+			ROCommunity: testSecretValue,
+			SysLocation: testSNMPLocation,
+		},
+	}
+	EnrichForExport(device)
 
 	const goroutines = 8
 	var wg sync.WaitGroup
 	wg.Add(goroutines)
 
-	for range goroutines {
+	for i := range goroutines {
+		redact := i%2 == 0
 		go func() {
 			defer wg.Done()
-			device := &common.CommonDevice{
-				System: common.System{Hostname: "race-test"},
-			}
-			EnrichForExport(device)
-			out := prepareForExport(device, true)
+			out := prepareForExport(device, redact)
 			if out.Statistics == nil {
-				t.Errorf("Statistics nil after enrich + prepareForExport")
+				t.Errorf("Statistics nil after concurrent prepareForExport (redact=%v)", redact)
+				return
+			}
+			details := out.Statistics.ServiceDetails
+			for j := range details {
+				if details[j].Name != analysis.ServiceNameSNMP || details[j].Details == nil {
+					continue
+				}
+				got := details[j].Details["community"]
+				want := testSecretValue
+				if redact {
+					want = redactedValue
+				}
+				if got != want {
+					t.Errorf("redact=%v: SNMP community = %q, want %q", redact, got, want)
+				}
 			}
 		}()
 	}
@@ -812,8 +831,8 @@ func TestEnrichForExport_FanOutAcrossDevicesIsRaceClean(t *testing.T) {
 func TestEnrichForExport_PrepareForExportSkipsRecomputation(t *testing.T) {
 	// Memoization invariant: after EnrichForExport, every prepareForExport call
 	// must reuse the cached Statistics/Analysis pointers (the heavy work runs
-	// once). This is the core NATS-37 contract — multi-format exports do not
-	// recompute analysis per format.
+	// once). This is the core memoization contract — multi-format exports do
+	// not recompute analysis per format.
 	t.Parallel()
 
 	device := &common.CommonDevice{
@@ -827,26 +846,25 @@ func TestEnrichForExport_PrepareForExportSkipsRecomputation(t *testing.T) {
 
 	for _, redact := range []bool{false, true} {
 		out := prepareForExport(device, redact)
+		// Source-of-truth invariant: the cache on the input device is never
+		// mutated by prepareForExport, regardless of redact direction.
 		assert.Same(t, cachedStats, device.Statistics,
 			"EnrichForExport result must outlive prepareForExport (redact=%v)", redact)
 		assert.Same(t, cachedAnalysis, device.Analysis,
 			"EnrichForExport result must outlive prepareForExport (redact=%v)", redact)
-		// Returned device must reuse the cached Analysis pointer regardless of
-		// redact (Analysis is never cloned).
+		// Returned device reuses the cached Analysis pointer (Analysis is
+		// never cloned by the redact path).
 		assert.Same(t, cachedAnalysis, out.Analysis,
 			"returned device reuses cached Analysis (redact=%v)", redact)
-		// Returned device's Statistics pointer must equal the cached pointer
-		// when no SNMP community redaction is required (this device has no SNMP
-		// configured, so redactStatisticsServiceDetails returns input unchanged
-		// even on the redact=true branch).
-		assert.Same(
-			t,
-			cachedStats,
-			out.Statistics,
-			"redactStatisticsServiceDetails returns cached Statistics when no SNMP community present (redact=%v)",
-			redact,
-		)
 	}
+
+	// Returned-Statistics pointer identity on the non-redact path is the
+	// memoization invariant. The redact path's pointer identity depends on
+	// whether the fixture has SNMP redaction to do, so it is pinned separately
+	// by TestRedactStatisticsServiceDetails_NoSNMPCommunity_ReturnsInputUnchanged.
+	plain := prepareForExport(device, false)
+	assert.Same(t, cachedStats, plain.Statistics,
+		"non-redact path returns cached Statistics directly")
 }
 
 func TestEnrichForExport_RedactDoesNotLeakIntoCachedStatistics(t *testing.T) {
@@ -945,9 +963,7 @@ func TestRedactStatisticsServiceDetails_MultipleSNMPEntries_AllRedacted(t *testi
 	// Defense-in-depth: if a future analysis writer ever emits multiple SNMP
 	// service entries (SNMPv3, separate read/write communities, multi-instance
 	// agents), every one of them carries cleartext community on the unredacted
-	// path. The redactor must redact ALL matches, not just the first — this is
-	// the regression NATS-37's initial implementation introduced via an early
-	// `break` and the fix removed.
+	// path. The redactor must redact ALL matches, not just the first.
 	t.Parallel()
 
 	stats := &common.Statistics{

--- a/internal/converter/enrichment_test.go
+++ b/internal/converter/enrichment_test.go
@@ -777,6 +777,39 @@ func TestEnrichForExport_NilDeviceIsSafe(t *testing.T) {
 	})
 }
 
+func TestEnrichForExport_ClearingStatisticsRefreshesDerivedFields(t *testing.T) {
+	// Cache-invalidation contract: when the caller clears Statistics to refresh
+	// after a config change, SecurityAssessment and PerformanceMetrics — both
+	// derived from Statistics — must also refresh. Otherwise the next export
+	// carries fresh statistics but stale derived metrics tied to the discarded
+	// Statistics.
+	t.Parallel()
+
+	device := &common.CommonDevice{
+		System: common.System{Hostname: "h"},
+	}
+	EnrichForExport(device)
+
+	priorStats := device.Statistics
+	priorSA := device.SecurityAssessment
+	priorPM := device.PerformanceMetrics
+	require.NotNil(t, priorStats)
+	require.NotNil(t, priorSA)
+	require.NotNil(t, priorPM)
+
+	// Simulate a config-change cache invalidation: clear only Statistics.
+	device.Statistics = nil
+
+	EnrichForExport(device)
+
+	require.NotNil(t, device.Statistics)
+	assert.NotSame(t, priorStats, device.Statistics, "Statistics refreshed after clear")
+	assert.NotSame(t, priorSA, device.SecurityAssessment,
+		"SecurityAssessment must refresh together with Statistics, not retain pointer to discarded view")
+	assert.NotSame(t, priorPM, device.PerformanceMetrics,
+		"PerformanceMetrics must refresh together with Statistics, not retain pointer to discarded view")
+}
+
 func TestEnrichForExport_FanOutFromSingleEnrichedDeviceIsRaceClean(t *testing.T) {
 	// EnrichForExport's documented supported pattern is "one device, enrich
 	// once, fan out exports": a caller invokes EnrichForExport on a *CommonDevice,
@@ -943,6 +976,10 @@ func TestRedactStatisticsServiceDetails_NoSNMPCommunity_ReturnsInputUnchanged(t 
 	}{
 		{name: "nil details", details: nil},
 		{name: "missing community key", details: map[string]string{"location": testSNMPLocation}},
+		// Empty-string community is treated as "not configured" by analysis —
+		// pin that the redactor's `ok && v != ""` guard returns the input
+		// pointer unchanged rather than flipping "" to "[REDACTED]".
+		{name: "empty community value", details: map[string]string{"community": "", "location": testSNMPLocation}},
 	}
 
 	for _, tc := range tests {

--- a/internal/converter/enrichment_test.go
+++ b/internal/converter/enrichment_test.go
@@ -3,6 +3,7 @@ package converter
 import (
 	"context"
 	"encoding/json"
+	"sync"
 	"testing"
 
 	"github.com/EvilBit-Labs/opnDossier/internal/analysis"
@@ -10,6 +11,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
+)
+
+// Test fixture constants. Extracted to satisfy goconst (literals appearing
+// 3+ times in the same package fail lint per GOTCHAS §1.4).
+const (
+	testSecretValue  = "supersecret"
+	testSNMPLocation = "office"
 )
 
 func TestPrepareForExport_PopulatesStatistics(t *testing.T) {
@@ -57,6 +65,10 @@ func TestPrepareForExport_PreservesExistingStatistics(t *testing.T) {
 
 	assert.Same(t, existing, result.Statistics, "Existing Statistics should be preserved")
 	assert.Equal(t, 42, result.Statistics.TotalInterfaces)
+	// Content of the pre-populated Statistics must remain unchanged after a
+	// non-redact prepareForExport — proves the shallow-copy path does not
+	// inadvertently mutate the caller's struct.
+	assert.Equal(t, 42, device.Statistics.TotalInterfaces)
 }
 
 func TestPrepareForExport_PreservesExistingAnalysis(t *testing.T) {
@@ -86,6 +98,8 @@ func TestPrepareForExport_DoesNotMutateInput(t *testing.T) {
 	assert.Equal(t, common.DeviceTypeUnknown, device.DeviceType, "Original should not be mutated")
 	assert.Nil(t, device.Statistics, "Original should not be mutated")
 	assert.Nil(t, device.Analysis, "Original should not be mutated")
+	assert.Nil(t, device.SecurityAssessment, "Original should not be mutated")
+	assert.Nil(t, device.PerformanceMetrics, "Original should not be mutated")
 	assert.NotSame(t, device, result, "Result should be a different pointer")
 }
 
@@ -393,7 +407,7 @@ func TestPrepareForExport_RedactsSensitiveFields_JSON(t *testing.T) {
 		HighAvailability: common.HighAvailability{Password: "secret123"},
 		Users: []common.User{{
 			Name:    "admin",
-			APIKeys: []common.APIKey{{Key: "k1", Secret: "supersecret"}},
+			APIKeys: []common.APIKey{{Key: "k1", Secret: testSecretValue}},
 		}},
 		SNMP: common.SNMPConfig{ROCommunity: "private-community"},
 		Certificates: []common.Certificate{
@@ -646,7 +660,7 @@ func TestComputeStatistics_SNMPCommunityInServiceDetails(t *testing.T) {
 	device := &common.CommonDevice{
 		SNMP: common.SNMPConfig{
 			ROCommunity: "my-community",
-			SysLocation: "office",
+			SysLocation: testSNMPLocation,
 			SysContact:  "admin@example.com",
 		},
 	}
@@ -667,7 +681,7 @@ func TestComputeStatistics_SNMPCommunityInServiceDetails(t *testing.T) {
 	require.NotNil(t, snmpService, "SNMP Daemon should be in ServiceDetails")
 	assert.Equal(t, "my-community", snmpService.Details["community"],
 		"ServiceDetails should contain the actual SNMP community, not [REDACTED]")
-	assert.Equal(t, "office", snmpService.Details["location"])
+	assert.Equal(t, testSNMPLocation, snmpService.Details["location"])
 	assert.Equal(t, "admin@example.com", snmpService.Details["contact"])
 }
 
@@ -713,4 +727,254 @@ func TestPrepareForExport_Redact_SNMPCommunityInServiceDetails(t *testing.T) {
 
 func TestNewFieldsSerialization(t *testing.T) {
 	RunNewFieldsSerializationTests(t)
+}
+
+func TestEnrichForExport_PopulatesNilFields(t *testing.T) {
+	t.Parallel()
+
+	device := &common.CommonDevice{
+		System: common.System{Hostname: "h", Domain: "d"},
+	}
+
+	EnrichForExport(device)
+
+	assert.Equal(t, common.DeviceTypeOPNsense, device.DeviceType)
+	require.NotNil(t, device.Statistics)
+	require.NotNil(t, device.Analysis)
+	require.NotNil(t, device.SecurityAssessment)
+	require.NotNil(t, device.PerformanceMetrics)
+}
+
+func TestEnrichForExport_PreservesExistingFields(t *testing.T) {
+	t.Parallel()
+
+	stats := &common.Statistics{TotalInterfaces: 7}
+	analysisIn := &common.Analysis{}
+	secAssess := &common.SecurityAssessment{}
+	perfMetrics := &common.PerformanceMetrics{}
+	device := &common.CommonDevice{
+		DeviceType:         common.DeviceTypePfSense,
+		Statistics:         stats,
+		Analysis:           analysisIn,
+		SecurityAssessment: secAssess,
+		PerformanceMetrics: perfMetrics,
+	}
+
+	EnrichForExport(device)
+
+	assert.Equal(t, common.DeviceTypePfSense, device.DeviceType, "existing DeviceType preserved")
+	assert.Same(t, stats, device.Statistics, "existing Statistics pointer preserved")
+	assert.Same(t, analysisIn, device.Analysis, "existing Analysis pointer preserved")
+	assert.Same(t, secAssess, device.SecurityAssessment, "existing SecurityAssessment pointer preserved")
+	assert.Same(t, perfMetrics, device.PerformanceMetrics, "existing PerformanceMetrics pointer preserved")
+}
+
+func TestEnrichForExport_NilDeviceIsSafe(t *testing.T) {
+	t.Parallel()
+
+	assert.NotPanics(t, func() {
+		EnrichForExport(nil)
+	})
+}
+
+func TestEnrichForExport_FanOutAcrossDevicesIsRaceClean(t *testing.T) {
+	// EnrichForExport's documented contract is "not safe for concurrent use on
+	// the same *CommonDevice", which implicitly says the *supported* pattern is
+	// fanning out across distinct devices in parallel — each goroutine owning
+	// its own *CommonDevice. Pin that with a -race regression: if a future
+	// refactor introduces hidden shared state inside enrich (e.g., a package
+	// cache), `go test -race` will catch it via this test.
+	//
+	// 3-reviewer cross-corroboration (correctness, security, adversarial)
+	// promoted this to anchor 100.
+	t.Parallel()
+
+	const goroutines = 8
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			device := &common.CommonDevice{
+				System: common.System{Hostname: "race-test"},
+			}
+			EnrichForExport(device)
+			out := prepareForExport(device, true)
+			if out.Statistics == nil {
+				t.Errorf("Statistics nil after enrich + prepareForExport")
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestEnrichForExport_PrepareForExportSkipsRecomputation(t *testing.T) {
+	// Memoization invariant: after EnrichForExport, every prepareForExport call
+	// must reuse the cached Statistics/Analysis pointers (the heavy work runs
+	// once). This is the core NATS-37 contract — multi-format exports do not
+	// recompute analysis per format.
+	t.Parallel()
+
+	device := &common.CommonDevice{
+		System: common.System{Hostname: "h"},
+	}
+
+	EnrichForExport(device)
+
+	cachedStats := device.Statistics
+	cachedAnalysis := device.Analysis
+
+	for _, redact := range []bool{false, true} {
+		out := prepareForExport(device, redact)
+		assert.Same(t, cachedStats, device.Statistics,
+			"EnrichForExport result must outlive prepareForExport (redact=%v)", redact)
+		assert.Same(t, cachedAnalysis, device.Analysis,
+			"EnrichForExport result must outlive prepareForExport (redact=%v)", redact)
+		// Returned device must reuse the cached Analysis pointer regardless of
+		// redact (Analysis is never cloned).
+		assert.Same(t, cachedAnalysis, out.Analysis,
+			"returned device reuses cached Analysis (redact=%v)", redact)
+		// Returned device's Statistics pointer must equal the cached pointer
+		// when no SNMP community redaction is required (this device has no SNMP
+		// configured, so redactStatisticsServiceDetails returns input unchanged
+		// even on the redact=true branch).
+		assert.Same(
+			t,
+			cachedStats,
+			out.Statistics,
+			"redactStatisticsServiceDetails returns cached Statistics when no SNMP community present (redact=%v)",
+			redact,
+		)
+	}
+}
+
+func TestEnrichForExport_RedactDoesNotLeakIntoCachedStatistics(t *testing.T) {
+	// Safety invariant: prepareForExport(redact=true) must not mutate the
+	// Statistics that EnrichForExport produced. Otherwise a subsequent
+	// non-redacted export would observe redacted values, and a caller that
+	// inspects device.Statistics after a redacted export would see leaked
+	// redaction markers.
+	t.Parallel()
+
+	device := &common.CommonDevice{
+		SNMP: common.SNMPConfig{
+			ROCommunity: testSecretValue,
+			SysLocation: testSNMPLocation,
+		},
+	}
+
+	EnrichForExport(device)
+
+	snmpDetailsBefore := snmpDetails(t, device.Statistics)
+	require.Equal(t, testSecretValue, snmpDetailsBefore["community"],
+		"baseline: enriched Statistics carries the unredacted community")
+
+	redacted := prepareForExport(device, true)
+
+	// Redacted export sees redacted community.
+	require.Equal(t, redactedValue, snmpDetails(t, redacted.Statistics)["community"])
+
+	// Cached Statistics on the original device retains the unredacted community.
+	assert.Equal(t, testSecretValue, snmpDetails(t, device.Statistics)["community"],
+		"cached Statistics must not be mutated by prepareForExport(redact=true)")
+
+	// And a subsequent non-redacted export still sees the real community.
+	plain := prepareForExport(device, false)
+	assert.Equal(t, testSecretValue, snmpDetails(t, plain.Statistics)["community"],
+		"non-redacted export after a redacted export still observes real values")
+}
+
+func TestEnrichForExport_NonRedactThenRedactDoesNotLeakIntoCachedStatistics(t *testing.T) {
+	// Reverse-direction safety invariant for the redaction-leak contract: a
+	// caller that does a non-redacted export first, then a redacted export on
+	// the same enriched device, must see the redacted output carry [REDACTED]
+	// while the cached Statistics on the original device retains the
+	// unredacted community.
+	t.Parallel()
+
+	device := &common.CommonDevice{
+		SNMP: common.SNMPConfig{
+			ROCommunity: testSecretValue,
+			SysLocation: testSNMPLocation,
+		},
+	}
+
+	EnrichForExport(device)
+
+	plain := prepareForExport(device, false)
+	require.Equal(t, testSecretValue, snmpDetails(t, plain.Statistics)["community"],
+		"baseline: non-redact export observes the real community")
+
+	redacted := prepareForExport(device, true)
+	assert.Equal(t, redactedValue, snmpDetails(t, redacted.Statistics)["community"],
+		"redact export after a non-redact export still produces redacted output")
+	assert.Equal(t, testSecretValue, snmpDetails(t, device.Statistics)["community"],
+		"cached Statistics must not be mutated by the redact export that followed")
+}
+
+func TestRedactStatisticsServiceDetails_NoSNMPCommunity_ReturnsInputUnchanged(t *testing.T) {
+	// Pins the early-return-same-pointer path in redactStatisticsServiceDetails:
+	// when no SNMP entry has a "community" key, the function must return the
+	// input pointer verbatim (no struct/slice clone).
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		details map[string]string
+	}{
+		{name: "nil details", details: nil},
+		{name: "missing community key", details: map[string]string{"location": testSNMPLocation}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			stats := &common.Statistics{
+				ServiceDetails: []common.ServiceStatistics{
+					{Name: analysis.ServiceNameSNMP, Details: tc.details},
+				},
+			}
+			out := redactStatisticsServiceDetails(stats)
+			assert.Same(t, stats, out, "no-redaction path must return input pointer unchanged")
+		})
+	}
+}
+
+func TestRedactStatisticsServiceDetails_MultipleSNMPEntries_AllRedacted(t *testing.T) {
+	// Defense-in-depth: if a future analysis writer ever emits multiple SNMP
+	// service entries (SNMPv3, separate read/write communities, multi-instance
+	// agents), every one of them carries cleartext community on the unredacted
+	// path. The redactor must redact ALL matches, not just the first — this is
+	// the regression NATS-37's initial implementation introduced via an early
+	// `break` and the fix removed.
+	t.Parallel()
+
+	stats := &common.Statistics{
+		ServiceDetails: []common.ServiceStatistics{
+			{Name: analysis.ServiceNameSNMP, Details: map[string]string{"community": "first"}},
+			{Name: "Other Service", Details: map[string]string{"foo": "bar"}},
+			{Name: analysis.ServiceNameSNMP, Details: map[string]string{"community": "second"}},
+		},
+	}
+
+	out := redactStatisticsServiceDetails(stats)
+	require.NotNil(t, out)
+	assert.Equal(t, redactedValue, out.ServiceDetails[0].Details["community"], "first SNMP entry redacted")
+	assert.Equal(t, redactedValue, out.ServiceDetails[2].Details["community"], "second SNMP entry redacted")
+	// Input is not mutated.
+	assert.Equal(t, "first", stats.ServiceDetails[0].Details["community"], "input first SNMP entry unchanged")
+	assert.Equal(t, "second", stats.ServiceDetails[2].Details["community"], "input second SNMP entry unchanged")
+}
+
+func snmpDetails(t *testing.T, stats *common.Statistics) map[string]string {
+	t.Helper()
+	require.NotNil(t, stats)
+	for i := range stats.ServiceDetails {
+		if stats.ServiceDetails[i].Name == analysis.ServiceNameSNMP {
+			return stats.ServiceDetails[i].Details
+		}
+	}
+	t.Fatalf("SNMP service entry not found in ServiceDetails")
+	return nil
 }


### PR DESCRIPTION
## Summary

`prepareForExport` recomputed `analysis.ComputeStatistics` and `analysis.ComputeAnalysis` on every call because its nil-check populated the local shallow copy rather than the input. Multi-format exports of the same `*CommonDevice` paid that O(n) cost once per format.

This change adds public `EnrichForExport(*CommonDevice)`. Callers preparing the same device for multiple format exports invoke it once before the format loop; subsequent `prepareForExport` calls inherit the populated `Statistics` / `Analysis` / `SecurityAssessment` / `PerformanceMetrics` pointers via the shallow copy and short-circuit the heavy passes.

## Redaction isolation

`redactStatisticsServiceDetails` is now non-mutating: it returns a clone of the affected `Statistics` struct + `ServiceDetails` slice + `Details` map when SNMP community redaction is required, or the input pointer unchanged otherwise. This lets one enriched `Statistics` be safely shared across mixed `redact=true` / `redact=false` callers without leaking redaction markers back into the caller's data.

The redactor also redacts every matching SNMP entry rather than the first, restoring pre-NATS-37 breadth — the initial implementation had an early `break` that would have left additional entries in cleartext if a future schema change ever surfaced multiple SNMP services.

## Performance

`BenchmarkMultiFormatExport` on `sample.config.6.xml` (~119KB, Apple M5):

| Variant | ns/op | B/op | allocs/op |
|---|---:|---:|---:|
| `PerFormatRecompute` (markdown + JSON + YAML) | 3,082,095 | 10,112,521 | 33,933 |
| `PreEnrichOnce` (markdown + JSON + YAML) | 2,995,281 | 9,943,828 | 32,890 |
| `PrepareForExportOnly_Recompute` | 126,929 | 259,527 | 1,551 |
| `PrepareForExportOnly_PreEnrich` | 44,095 | 91,888 | 519 |

The bare `prepareForExport` sub-benchmarks isolate the analysis cost: **~65% latency and ~65% allocation reduction**. The headline multi-format numbers amortize that win across markdown rendering and JSON/YAML marshaling, where serialization dominates — the realistic CLI workload sees ~7.7% latency reduction.

A precondition guard in the benchmark fails loudly if a future parser change pre-populates `Statistics` and silently degenerates both variants to the same workload.

## Contract

`EnrichForExport` is opt-in. The single-format export path is unchanged; `prepareForExport` continues to not mutate its input. Documented contracts on the new function:

- The resulting device carries plaintext secrets in `Statistics.ServiceDetails`. Callers must not marshal or log the device directly post-enrichment — always pass through `prepareForExport` (or a Generator that does).
- Post-call mutation of fields that feed the cached computations (e.g., `device.SNMP.ROCommunity`, `FirewallRules`) invalidates the cache; re-call after clearing the affected enrichment field.
- Not safe for concurrent use on the same `*CommonDevice`. The supported pattern is fan-out across distinct devices, pinned by `TestEnrichForExport_FanOutAcrossDevicesIsRaceClean` under `-race`.

## Test Plan

- [x] `go test -count=1 ./internal/converter/...` clean
- [x] `go test -race ./internal/converter/...` clean (covers fan-out and redaction-isolation invariants)
- [x] `go test -count=1 ./...` whole-repo regression clean
- [x] `golangci-lint run ./internal/converter/...` 0 issues
- [x] `go test -bench=BenchmarkMultiFormatExport -benchmem` reproduces the documented speedup
- [ ] CI green on this PR

Nine new regression tests pin the contracts: memoization (every `prepareForExport` reuses cached pointers), redaction isolation in both directions, nil-safety, all-SNMP-entries redaction, and the `-race` fan-out pattern.

## AI Disclosure

Used Claude Code (`Claude Opus 4.7 (1M Context)`) for design, implementation, and review. All code reviewed and tested locally with `go test -race`, `golangci-lint`, and `go test -bench`. See [AI_POLICY.md](AI_POLICY.md).


## Follow-up

[NATS-163](https://evilbitlabs.atlassian.net/browse/NATS-163) tracks deduplicating SNMP-community redaction across `internal/processor` and `internal/converter` — the two implementations now exist in parallel because the convergence work is cross-package and outside this PR's scope.


[NATS-163]: https://evilbitlabs.atlassian.net/browse/NATS-163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ