### PR TITLE
refactor: deduplicate SNMP ServiceDetails redaction + close SNMPv3 enckey sanitizer leak (NATS-163)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,1 @@
-{
-  "enabledPlugins": {
-    "ecc@everything-claude-code": true,
-    "compound-engineering@compound-engineering-plugin": true,
-    "golang-development@geoffjay-claude-plugins": true
-  }
-}
+{}

--- a/.mdformat.toml
+++ b/.mdformat.toml
@@ -1,14 +1,8 @@
-exclude = [
-  "venv/**",
-  "**/node_modules/**",
-  "**/*.txt",
-  "**/*.mdc",
-  "**/*.tpl.md",
-  "**/CHANGELOG.md",
-  "target/**",
-  "megalinter-reports/**",
-  "THIRD_PARTY_NOTICES",
-]
+# NOTE: file exclusions are handled by the mdformat pre-commit hook's native
+# `exclude:` regex in .pre-commit-config.yaml, NOT here. mdformat's own `exclude`
+# config key requires the hook to run under Python 3.13+ (pre-commit builds the
+# hook venv with its own interpreter, currently 3.11), so using it breaks
+# `pre-commit run`. The pre-commit `exclude:` regex is Python-version independent.
 validate = true
 number = true
 wrap = "no"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,10 @@ repos:
         # - docs/cli/: Cobra-generated CLI reference — mdformat would collapse the
         #   indented prose blocks into single lines that then diverge from the
         #   regenerated output on every `just generate-cli-docs` run.
-        exclude: (\.golden\.md$|^docs/cli/)
+        # - CHANGELOG.md: generated; reformatting causes churn and merge conflicts.
+        # - *.tpl.md: templates with placeholder syntax mdformat would mangle.
+        # (Migrated from .mdformat.toml `exclude`, which requires Python 3.13+.)
+        exclude: (\.golden\.md$|^docs/cli/|(^|/)CHANGELOG\.md$|\.tpl\.md$)
 
   # Go linting — mirrors `just lint` / CI lint job. Uses local hooks that
   # delegate to the mise-pinned golangci-lint (mise.toml → 2.11.4) to keep a

--- a/GOTCHAS.md
+++ b/GOTCHAS.md
@@ -462,3 +462,24 @@ All other slices on the input (`Interfaces`, `VLANs`, `Bridges`, `CAs`, etc.) sh
 - **`WorkerPool.closedMu sync.RWMutex`** (`internal/processor/concurrent.go`) — channel-close guard in the worker pool used by `ProcessBatch`. Concrete: prevents a `send on closed channel` panic when one goroutine calls `Close()` while another is mid-`Submit`.
 
 Do not remove either of these in a "clean up the package's locks" sweep. They protect distinct invariants from the one §21.1 addressed.
+
+## 22. Documentation Tooling
+
+### 22.1 mdformat Collapses Consecutive `**Label**:` Lines
+
+With `wrap = "no"` in `.mdformat.toml`, mdformat joins consecutive `**Label**:` lines onto a SINGLE line. ADR frontmatter written as three lines —
+
+```markdown
+**Date**: YYYY-MM-DD
+**Status**: accepted
+**Deciders**: ...
+```
+
+— renders after the pre-commit hook as one line: `**Date**: YYYY-MM-DD **Status**: accepted **Deciders**: ...`. That collapsed form is canonical.
+
+- **Gotcha:** Do not "fix" these back onto separate lines — the `mdformat` pre-commit hook re-collapses them and the edit will not survive a commit. Both `docs/adr/template.md` and the ADRs are kept in the collapsed form, so they are already mutually consistent.
+- **Gotcha:** Reviewers (e.g. CodeRabbit) sometimes flag the collapsed frontmatter as a layout defect and suggest splitting the lines. That suggestion is a false positive against this repo's formatter — decline it.
+
+### 22.2 mdformat Excludes Live in `.pre-commit-config.yaml`, Not `.mdformat.toml`
+
+File exclusions for the `mdformat` hook are the pre-commit hook's native `exclude:` regex in `.pre-commit-config.yaml` (currently `*.golden.md`, `docs/cli/`, `CHANGELOG.md`, `*.tpl.md`). Do NOT reintroduce an `exclude = [...]` list in `.mdformat.toml`: that feature requires the hook to run under Python 3.13+, but pre-commit builds the hook venv with its own interpreter (3.11 today), so it fails on every markdown file with `'exclude' patterns are only available on Python 3.13+`.

--- a/docs/adr/0001-opnsense-pfsense-snmp-config-storage-model.md
+++ b/docs/adr/0001-opnsense-pfsense-snmp-config-storage-model.md
@@ -1,0 +1,64 @@
+# ADR-0001: SNMP configuration storage model in OPNsense and pfSense
+
+**Date**: 2026-06-27 **Status**: accepted **Deciders**: UncleSp1d3r (maintainer), Claude Code (Opus 4.8)
+
+## Context
+
+opnDossier redacts the SNMP community string in statistics and exports. A scope question (deduplicating that redaction) raised a follow-on: should redaction also cover SNMPv3 authentication and privacy secrets? Answering responsibly required examining the upstream OPNsense and pfSense source to determine exactly where SNMP credentials are persisted in `config.xml`. This ADR records those verified findings so future SNMP parser, statistics, and sanitizer work starts from facts rather than assumptions. The findings are the durable artifact here; the scoping choice they enabled is a consequence, not the decision.
+
+## Findings (verified against vendor source)
+
+### pfSense (base / CE)
+
+- SNMP is `bsnmpd`. Config lives under `<snmpd>` with `rocommunity` (plus `syslocation`, `syscontact`). Community-only — **no SNMPv3** in base `config.xml`. (`src/usr/local/www/services_snmp.php`, `src/etc/inc/services.inc`)
+- pfSense itself treats `rocommunity` as a secret: it appears in the masked-field list in `src/usr/local/pfSense/include/www/status_output.inc`.
+
+### OPNsense core
+
+- Base `<snmpd>` carries only `syslocation`, `syscontact`, `rocommunity` (`bsnmpd`, v1/v2c). **No SNMPv3** in core `config.xml`.
+
+### OPNsense `os-net-snmp` plugin (`net-mgmt/net-snmp`)
+
+- SNMPv3 lives here, persisted to `config.xml` under `<OPNsense><netsnmp>`. The MVC models mount at `//OPNsense/netsnmp/general` and `//OPNsense/netsnmp/user`.
+- **general** (model v1.0.5): `enabled`, `community`, `syslocation`, `syscontact`, `l3visibility`, `versionoid`, `enableagentx`, `enableobservium`, `listen`.
+- **user/users/user[]** (model v1.0.1): `enabled`, `username`, **`password`** (SNMPv3 auth passphrase — cleartext `TextField`, 8–64 chars), **`enckey`** (privacy/encryption key — cleartext `TextField`, 8–64 chars), `readwrite`.
+- Credentials are stored cleartext in `config.xml`; the daemon template renders them to `snmpd_usercredentials.conf`.
+
+### opnDossier today
+
+- Parses only the base `<snmpd>` → `pkg/schema/opnsense/services.go` `Snmpd{SysLocation, SysContact, ROCommunity}`. The `<OPNsense><netsnmp>` plugin namespace is **not parsed anywhere** (no references in `pkg/` or `internal/`).
+- The `sanitize` command walks **raw XML element names**, so credential redaction does not depend on the model parsing the plugin namespace.
+
+## Decision
+
+Scope opnDossier's SNMP credential handling to what the vendor source actually persists, as enumerated above: `rocommunity` (base), and the net-snmp plugin's `password` and `enckey`. Model-based SNMPv3 features require parsing the `<OPNsense><netsnmp>` namespace, which opnDossier does not do today.
+
+## Alternatives Considered
+
+### Alternative: Model SNMPv3 ingestion as part of current SNMP work
+
+- **Pros**: One tracked item covering statistics and redaction across all SNMP versions.
+- **Cons**: Requires building a parser for the `<OPNsense><netsnmp>` plugin namespace (a new schema surface); pfSense base has no SNMPv3 to model, so coverage would be OPNsense-plugin-only.
+- **Why not**: SNMPv3 ingestion is a feature with its own prerequisite and is not required by the current community-redaction work; it is tracked separately.
+
+## Consequences
+
+### Positive
+
+- Future SNMP parser, statistics, and sanitizer work starts from verified field names, storage locations, and model versions.
+- The community-redaction dedup can proceed as a behavior-neutral refactor; a centralized sensitive-key list makes adding `password`/`enckey` a one-line change once the namespace is parsed.
+
+### Negative
+
+- The `<OPNsense><netsnmp>` namespace remains unparsed, so SNMPv3 secrets stay invisible to model-based features until that work lands.
+
+### Risks
+
+- **Schema version drift.** The plugin model element names/versions can change across OPNsense releases (general v1.0.5, user v1.0.1 at time of writing). Re-verify against a real `config.xml` when implementing ingestion (cf. GOTCHAS §18.1 version-pinning).
+
+## Sources
+
+- `opnsense/plugins` — `net-mgmt/net-snmp/src/opnsense/mvc/app/models/OPNsense/Netsnmp/General.xml`, `.../User.xml`; template target `snmpd_usercredentials.conf`
+- `opnsense/core` — base `<snmpd>` handling
+- `pfsense/pfsense` — `src/usr/local/www/services_snmp.php`, `src/etc/inc/services.inc`, `src/usr/local/pfSense/include/www/status_output.inc`
+- opnDossier — `pkg/schema/opnsense/services.go` (`Snmpd`), `internal/analysis/statistics.go` (`populateServiceStats`)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,9 @@
+# Architecture Decision Records
+
+This directory records architectural decisions and verified findings that shape opnDossier. Each ADR is a short, durable note: the context, the decision (or the verified reality we depend on), the alternatives weighed, and the consequences.
+
+See [template.md](template.md) for the blank format.
+
+| ADR                                                        | Title                                                    | Status   | Date       |
+| ---------------------------------------------------------- | -------------------------------------------------------- | -------- | ---------- |
+| [0001](0001-opnsense-pfsense-snmp-config-storage-model.md) | SNMP configuration storage model in OPNsense and pfSense | accepted | 2026-06-27 |

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,33 @@
+# ADR-NNNN: [Decision Title]
+
+**Date**: YYYY-MM-DD **Status**: proposed | accepted | deprecated | superseded by ADR-NNNN **Deciders**: [who was involved]
+
+## Context
+
+What is the issue that is motivating this decision or finding? Describe the situation, constraints, and forces at play in 2-5 sentences.
+
+## Decision
+
+What is the change we are making, or the verified reality we are committing to depend on? State it clearly in 1-3 sentences.
+
+## Alternatives Considered
+
+### Alternative 1: [Name]
+
+- **Pros**: [benefits]
+- **Cons**: [drawbacks]
+- **Why not**: [specific reason this was rejected]
+
+## Consequences
+
+### Positive
+
+- [benefit]
+
+### Negative
+
+- [trade-off]
+
+### Risks
+
+- [risk and mitigation]

--- a/docs/dev-guide/contributing.md
+++ b/docs/dev-guide/contributing.md
@@ -198,7 +198,7 @@ Validate and sanitize all inputs at system boundaries. CLI arguments, configurat
 
 Use restrictive file permissions for sensitive material. Configuration files and any outputs containing sensitive data should be written with `0600` permissions.
 
-Keep error messages safe for operators and safe for logs. Do not leak credentials, raw configuration secrets, internal-only filesystem details, or sensitive values in returned errors. The SNMP community redaction logic in `internal/processor/report.go` is the canonical example of how sensitive values should be handled.
+Keep error messages safe for operators and safe for logs. Do not leak credentials, raw configuration secrets, internal-only filesystem details, or sensitive values in returned errors. The SNMP ServiceDetails redaction logic in `internal/analysis/statistics_redact.go` (specifically the `RedactServiceDetails` function) is the canonical example of how sensitive values should be handled.
 
 Never commit secrets to source control. Use environment variables or secure secret storage when a secret is genuinely required. For the full vulnerability reporting process and threat model, see `SECURITY.md` and `docs/security/security-assurance.md`.
 

--- a/internal/analysis/statistics_redact.go
+++ b/internal/analysis/statistics_redact.go
@@ -10,8 +10,10 @@ import (
 // serviceDetailRedactedValue is the placeholder written over sensitive
 // ServiceDetails values. It MUST remain "[REDACTED]" to preserve byte-identical
 // rendered output across the processor statistics path and the converter export
-// path — both delegate to RedactServiceDetails, so this string is the single
-// source of truth for the marker.
+// path — both delegate to RedactServiceDetails, so this constant is the single
+// source of truth for the ServiceDetails redaction marker. (The converter's
+// separate redactedValue const governs unrelated field redactions — certs, API
+// keys, WireGuard PSKs — and is not shared with this path.)
 const serviceDetailRedactedValue = "[REDACTED]"
 
 // snmpSensitiveDetailKeys lists the keys in ServiceStatistics.Details (for the
@@ -19,6 +21,11 @@ const serviceDetailRedactedValue = "[REDACTED]"
 // sensitive key — for example, an SNMPv3 authentication password surfaced once
 // the OPNsense net-snmp plugin namespace is parsed — is a one-line append here,
 // shared by every caller of RedactServiceDetails.
+//
+// When adding a key here, also verify the sanitizer's password/private_key
+// FieldPatterns in internal/sanitizer/rules.go cover the corresponding raw XML
+// element, so the raw-XML path stays in sync with this analysis path
+// (GOTCHAS §11.2).
 //
 //nolint:gochecknoglobals // immutable allowlist; mutation would be a security regression
 var snmpSensitiveDetailKeys = []string{"community"}

--- a/internal/analysis/statistics_redact.go
+++ b/internal/analysis/statistics_redact.go
@@ -1,0 +1,85 @@
+package analysis
+
+import (
+	"maps"
+	"slices"
+
+	common "github.com/EvilBit-Labs/opnDossier/pkg/model"
+)
+
+// serviceDetailRedactedValue is the placeholder written over sensitive
+// ServiceDetails values. It MUST remain "[REDACTED]" to preserve byte-identical
+// rendered output across the processor statistics path and the converter export
+// path — both delegate to RedactServiceDetails, so this string is the single
+// source of truth for the marker.
+const serviceDetailRedactedValue = "[REDACTED]"
+
+// snmpSensitiveDetailKeys lists the keys in ServiceStatistics.Details (for the
+// SNMP service entry) whose values must be redacted on export. Adding a new
+// sensitive key — for example, an SNMPv3 authentication password surfaced once
+// the OPNsense net-snmp plugin namespace is parsed — is a one-line append here,
+// shared by every caller of RedactServiceDetails.
+//
+//nolint:gochecknoglobals // immutable allowlist; mutation would be a security regression
+var snmpSensitiveDetailKeys = []string{"community"}
+
+// RedactServiceDetails returns a copy of details whose sensitive SNMP detail
+// values are replaced with the redaction marker, plus a flag indicating whether
+// any redaction was applied.
+//
+// The input is never mutated. When at least one SNMP entry carries a non-empty
+// sensitive key the slice is cloned and only the affected per-element Details
+// maps are cloned (clone-on-write); the second return is true. When nothing
+// matches, the input slice is returned unchanged and the second return is false,
+// letting non-mutating callers (e.g. the converter's memoized Statistics) skip
+// allocating a new container.
+//
+// Every matching SNMP entry is redacted — not just the first — and every key in
+// snmpSensitiveDetailKeys is redacted on each match. analysis.ComputeStatistics
+// emits a single SNMP entry with a single sensitive key today, but a future
+// schema change could surface multiple; leaving any in cleartext would be a
+// security regression.
+func RedactServiceDetails(details []common.ServiceStatistics) ([]common.ServiceStatistics, bool) {
+	var matches []int
+	for i := range details {
+		if details[i].Name != ServiceNameSNMP {
+			continue
+		}
+		if details[i].Details == nil {
+			continue
+		}
+		if hasSensitiveSNMPKey(details[i].Details) {
+			matches = append(matches, i)
+		}
+	}
+	if len(matches) == 0 {
+		return details, false
+	}
+
+	out := slices.Clone(details)
+	for _, idx := range matches {
+		out[idx].Details = maps.Clone(details[idx].Details)
+		for _, key := range snmpSensitiveDetailKeys {
+			// Value-aware guard: only replace when the value is present and
+			// non-empty, so empty-string placeholders are not flipped to
+			// "[REDACTED]" (which would shift the semantic meaning a downstream
+			// consumer reads from the field).
+			if v, ok := out[idx].Details[key]; ok && v != "" {
+				out[idx].Details[key] = serviceDetailRedactedValue
+			}
+		}
+	}
+
+	return out, true
+}
+
+// hasSensitiveSNMPKey reports whether details carries any snmpSensitiveDetailKeys
+// entry with a non-empty value.
+func hasSensitiveSNMPKey(details map[string]string) bool {
+	for _, key := range snmpSensitiveDetailKeys {
+		if v, ok := details[key]; ok && v != "" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/analysis/statistics_redact_test.go
+++ b/internal/analysis/statistics_redact_test.go
@@ -1,0 +1,119 @@
+package analysis_test
+
+import (
+	"testing"
+
+	"github.com/EvilBit-Labs/opnDossier/internal/analysis"
+	common "github.com/EvilBit-Labs/opnDossier/pkg/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const redactedMarker = "[REDACTED]"
+
+func snmpEntry(community string) common.ServiceStatistics {
+	return common.ServiceStatistics{
+		Name:    analysis.ServiceNameSNMP,
+		Enabled: true,
+		Details: map[string]string{
+			"location":  "datacenter-1",
+			"contact":   "admin@example.com",
+			"community": community,
+		},
+	}
+}
+
+func TestRedactServiceDetails_RedactsCommunityWithoutMutatingInput(t *testing.T) {
+	t.Parallel()
+
+	input := []common.ServiceStatistics{snmpEntry("s3cr3t-community")}
+
+	out, changed := analysis.RedactServiceDetails(input)
+
+	require.True(t, changed)
+	assert.Equal(t, redactedMarker, out[0].Details["community"])
+	// Non-mutation: the original input map is untouched.
+	assert.Equal(t, "s3cr3t-community", input[0].Details["community"])
+	// Other detail keys are preserved on the redacted copy.
+	assert.Equal(t, "datacenter-1", out[0].Details["location"])
+	assert.Equal(t, "admin@example.com", out[0].Details["contact"])
+}
+
+func TestRedactServiceDetails_EmptyCommunityNotFlipped(t *testing.T) {
+	t.Parallel()
+
+	input := []common.ServiceStatistics{snmpEntry("")}
+
+	out, changed := analysis.RedactServiceDetails(input)
+
+	require.False(t, changed)
+	assert.Empty(t, out[0].Details["community"])
+	assert.NotEqual(t, redactedMarker, out[0].Details["community"])
+}
+
+func TestRedactServiceDetails_NoSNMPEntry(t *testing.T) {
+	t.Parallel()
+
+	input := []common.ServiceStatistics{
+		{Name: "SSH Daemon", Enabled: true, Details: map[string]string{"group": "admins"}},
+	}
+
+	out, changed := analysis.RedactServiceDetails(input)
+
+	require.False(t, changed)
+	assert.Equal(t, "admins", out[0].Details["group"])
+}
+
+func TestRedactServiceDetails_NilDetails(t *testing.T) {
+	t.Parallel()
+
+	input := []common.ServiceStatistics{
+		{Name: analysis.ServiceNameSNMP, Enabled: true, Details: nil},
+	}
+
+	out, changed := analysis.RedactServiceDetails(input)
+
+	require.False(t, changed)
+	assert.Nil(t, out[0].Details)
+}
+
+func TestRedactServiceDetails_MultipleSNMPEntriesAllRedacted(t *testing.T) {
+	t.Parallel()
+
+	input := []common.ServiceStatistics{
+		snmpEntry("first-community"),
+		{Name: "SSH Daemon", Enabled: true, Details: map[string]string{"group": "admins"}},
+		snmpEntry("second-community"),
+	}
+
+	out, changed := analysis.RedactServiceDetails(input)
+
+	require.True(t, changed)
+	assert.Equal(t, redactedMarker, out[0].Details["community"])
+	assert.Equal(t, redactedMarker, out[2].Details["community"])
+	assert.Equal(t, "admins", out[1].Details["group"])
+}
+
+func TestRedactServiceDetails_NonSNMPCommunityKeyUntouched(t *testing.T) {
+	t.Parallel()
+
+	// A non-SNMP service that happens to carry a "community" key must not be
+	// redacted — the name gate protects it.
+	input := []common.ServiceStatistics{
+		{Name: "Some Other Service", Enabled: true, Details: map[string]string{"community": "not-secret"}},
+	}
+
+	out, changed := analysis.RedactServiceDetails(input)
+
+	require.False(t, changed)
+	assert.Equal(t, "not-secret", out[0].Details["community"])
+}
+
+func TestRedactServiceDetails_NilInput(t *testing.T) {
+	t.Parallel()
+
+	out, changed := analysis.RedactServiceDetails(nil)
+
+	require.False(t, changed)
+	assert.Empty(t, out)
+}

--- a/internal/converter/enrichment.go
+++ b/internal/converter/enrichment.go
@@ -1,7 +1,6 @@
 package converter
 
 import (
-	"maps"
 	"slices"
 
 	"github.com/EvilBit-Labs/opnDossier/internal/analysis"
@@ -25,15 +24,6 @@ func computePerformanceMetrics(stats *common.Statistics) *common.PerformanceMetr
 
 // redactedValue is the placeholder for sensitive fields in exported output.
 const redactedValue = "[REDACTED]"
-
-// snmpSensitiveDetailKeys lists the keys in Statistics.ServiceDetails[].Details
-// (for the SNMP service entry) whose values must be redacted on export.
-// Adding a new sensitive key — for example, an SNMPv3 authentication password
-// surfaced by a future analysis writer — is a one-line append here, not a
-// rewrite of the redaction loop in redactStatisticsServiceDetails.
-//
-//nolint:gochecknoglobals // immutable allowlist; mutation would be a security regression
-var snmpSensitiveDetailKeys = []string{"community"}
 
 // EnrichForExport populates the read-only enrichment fields on data in place
 // when they are nil: DeviceType (defaulting to OPNsense), Statistics, Analysis,
@@ -269,67 +259,24 @@ func redactDHCPv6Secrets(cp *common.CommonDevice) {
 }
 
 // redactStatisticsServiceDetails returns a Statistics whose sensitive
-// ServiceDetails values are replaced with the redaction marker. The input is
-// not mutated: when redaction is required the function clones the Statistics
-// struct, the ServiceDetails slice, and the affected per-element Details map.
-// When no SNMP entry carries any sensitive key, the input pointer is returned
-// unchanged. This non-mutating contract lets EnrichForExport memoize a single
-// Statistics across mixed redact=true and redact=false callers without leaking
-// redacted values into the caller's data.
-//
-// Every matching SNMP entry is redacted (not just the first), and every key
-// in snmpSensitiveDetailKeys is redacted on each match.
-// analysis.ComputeStatistics emits a single SNMP entry with a single sensitive
-// key today, but a future schema change — SNMPv3 with both community and auth
-// password, separate read/write communities, multi-instance agents — could
-// surface multiple. Leaving any of them in cleartext would be a security
-// regression.
+// ServiceDetails values are replaced with the redaction marker. It delegates to
+// analysis.RedactServiceDetails (the single primitive shared with the processor
+// statistics path) and preserves a non-mutating contract: when nothing is
+// redacted the input pointer is returned unchanged, so EnrichForExport can
+// memoize a single Statistics across mixed redact=true and redact=false callers
+// without leaking redacted values into the caller's data. Only when redaction
+// occurs is the Statistics struct cloned around the already-cloned slice.
 func redactStatisticsServiceDetails(stats *common.Statistics) *common.Statistics {
 	if stats == nil {
 		return nil
 	}
 
-	var matches []int
-	for i := range stats.ServiceDetails {
-		if stats.ServiceDetails[i].Name != analysis.ServiceNameSNMP {
-			continue
-		}
-		if stats.ServiceDetails[i].Details == nil {
-			continue
-		}
-		if hasSensitiveSNMPKey(stats.ServiceDetails[i].Details) {
-			matches = append(matches, i)
-		}
-	}
-	if len(matches) == 0 {
+	redacted, changed := analysis.RedactServiceDetails(stats.ServiceDetails)
+	if !changed {
 		return stats
 	}
 
 	out := *stats
-	out.ServiceDetails = slices.Clone(stats.ServiceDetails)
-	for _, idx := range matches {
-		out.ServiceDetails[idx].Details = maps.Clone(stats.ServiceDetails[idx].Details)
-		for _, key := range snmpSensitiveDetailKeys {
-			// Match the value-aware guard used by every other redactor in this
-			// file (cert/CA private keys, API key secrets, WireGuard PSKs,
-			// DHCPv6 secrets, HA password, SNMP ROCommunity): only replace when
-			// the value is actually present and non-empty. Stops empty-string
-			// placeholders from being flipped to "[REDACTED]", which would shift
-			// the semantic meaning a downstream consumer reads from the field.
-			if v, ok := out.ServiceDetails[idx].Details[key]; ok && v != "" {
-				out.ServiceDetails[idx].Details[key] = redactedValue
-			}
-		}
-	}
-
+	out.ServiceDetails = redacted
 	return &out
-}
-
-func hasSensitiveSNMPKey(details map[string]string) bool {
-	for _, key := range snmpSensitiveDetailKeys {
-		if v, ok := details[key]; ok && v != "" {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/converter/enrichment_test.go
+++ b/internal/converter/enrichment_test.go
@@ -1031,3 +1031,44 @@ func snmpDetails(t *testing.T, stats *common.Statistics) map[string]string {
 	t.Fatalf("SNMP service entry not found in ServiceDetails")
 	return nil
 }
+
+// TestRedactStatisticsServiceDetails_ConvergesWithProcessorPath pins R3: the
+// converter export path and the processor statistics path produce identical
+// ServiceDetails redaction for the same input, because both delegate to
+// analysis.RedactServiceDetails. The processor's generateStatistics applies the
+// primitive to commonStats.ServiceDetails before translating, so the operation
+// computed here is the exact processor-side redaction.
+func TestRedactStatisticsServiceDetails_ConvergesWithProcessorPath(t *testing.T) {
+	t.Parallel()
+
+	cfg := &common.CommonDevice{
+		SNMP: common.SNMPConfig{
+			ROCommunity: testSecretValue,
+			SysLocation: testSNMPLocation,
+		},
+	}
+
+	converterStats := redactStatisticsServiceDetails(analysis.ComputeStatistics(cfg))
+	processorDetails, changed := analysis.RedactServiceDetails(analysis.ComputeStatistics(cfg).ServiceDetails)
+
+	require.NotNil(t, converterStats)
+	require.True(t, changed, "expected redaction to occur")
+	assert.Equal(t, processorDetails, converterStats.ServiceDetails,
+		"converter and processor redaction paths must produce identical ServiceDetails")
+	assert.Equal(t, "[REDACTED]", snmpDetails(t, converterStats)["community"])
+}
+
+// TestRedactStatisticsServiceDetails_NoSNMP_BothPathsAgree pins that the two
+// paths still agree when there is nothing to redact.
+func TestRedactStatisticsServiceDetails_NoSNMP_BothPathsAgree(t *testing.T) {
+	t.Parallel()
+
+	cfg := &common.CommonDevice{}
+
+	converterStats := redactStatisticsServiceDetails(analysis.ComputeStatistics(cfg))
+	processorDetails, changed := analysis.RedactServiceDetails(analysis.ComputeStatistics(cfg).ServiceDetails)
+
+	require.NotNil(t, converterStats)
+	assert.False(t, changed, "no redaction expected with no SNMP service")
+	assert.Equal(t, processorDetails, converterStats.ServiceDetails)
+}

--- a/internal/converter/enrichment_test.go
+++ b/internal/converter/enrichment_test.go
@@ -1055,7 +1055,7 @@ func TestRedactStatisticsServiceDetails_ConvergesWithProcessorPath(t *testing.T)
 	require.True(t, changed, "expected redaction to occur")
 	assert.Equal(t, processorDetails, converterStats.ServiceDetails,
 		"converter and processor redaction paths must produce identical ServiceDetails")
-	assert.Equal(t, "[REDACTED]", snmpDetails(t, converterStats)["community"])
+	assert.Equal(t, redactedValue, snmpDetails(t, converterStats)["community"])
 }
 
 // TestRedactStatisticsServiceDetails_NoSNMP_BothPathsAgree pins that the two

--- a/internal/processor/report_statistics.go
+++ b/internal/processor/report_statistics.go
@@ -1,8 +1,6 @@
 package processor
 
 import (
-	"maps"
-
 	"github.com/EvilBit-Labs/opnDossier/internal/analysis"
 	common "github.com/EvilBit-Labs/opnDossier/pkg/model"
 )
@@ -91,31 +89,18 @@ type StatisticsSummary struct {
 	HasSecurityFeatures bool `json:"hasSecurityFeatures"`
 }
 
-// redactServiceDetails replaces sensitive values in the processor's ServiceDetails
-// with the redaction marker. The shared analysis.ComputeStatistics intentionally
-// returns raw values so callers can decide on redaction policy; the processor
-// always redacts before rendering or serializing.
-func redactServiceDetails(stats *Statistics) {
-	if stats == nil {
-		return
-	}
-
-	for i := range stats.ServiceDetails {
-		if stats.ServiceDetails[i].Name == analysis.ServiceNameSNMP && stats.ServiceDetails[i].Details != nil {
-			if _, ok := stats.ServiceDetails[i].Details["community"]; ok {
-				// Deep-copy the map to avoid mutating shared state.
-				stats.ServiceDetails[i].Details = maps.Clone(stats.ServiceDetails[i].Details)
-				stats.ServiceDetails[i].Details["community"] = redactedValue
-			}
-		}
-	}
-}
-
 // generateStatistics analyzes a device configuration and returns aggregated statistics.
 // It delegates to analysis.ComputeStatistics for shared logic, translates the result
 // into the processor's Statistics type, and adds IDS-specific fields.
 func generateStatistics(cfg *common.CommonDevice) *Statistics {
 	commonStats := analysis.ComputeStatistics(cfg)
+	// Redact sensitive service details on the shared statistics before translating
+	// into the processor type, using the same primitive as the converter export
+	// path (the single source of truth for SNMP redaction). commonStats is freshly
+	// owned by this call, so redacting it here is safe; translateCommonStats then
+	// copies the already-redacted Details maps.
+	commonStats.ServiceDetails, _ = analysis.RedactServiceDetails(commonStats.ServiceDetails)
+
 	stats := translateCommonStats(commonStats)
 
 	// IDS/IPS statistics — processor-specific fields not in common.Statistics
@@ -132,9 +117,6 @@ func generateStatistics(cfg *common.CommonDevice) *Statistics {
 			stats.IDSMode = "IDS (Detection Only)"
 		}
 	}
-
-	// Redact sensitive service details before the report can be rendered or serialized.
-	redactServiceDetails(stats)
 
 	return stats
 }

--- a/internal/processor/report_statistics.go
+++ b/internal/processor/report_statistics.go
@@ -96,9 +96,11 @@ func generateStatistics(cfg *common.CommonDevice) *Statistics {
 	commonStats := analysis.ComputeStatistics(cfg)
 	// Redact sensitive service details on the shared statistics before translating
 	// into the processor type, using the same primitive as the converter export
-	// path (the single source of truth for SNMP redaction). commonStats is freshly
-	// owned by this call, so redacting it here is safe; translateCommonStats then
-	// copies the already-redacted Details maps.
+	// path. commonStats is freshly owned by this call, so redacting it here is
+	// safe; translateCommonStats then aliases the already-redacted Details maps
+	// (cloned by the primitive, so sharing the references is safe). The discarded
+	// bool is informational ("redaction occurred"), not an error — the primitive
+	// has no failure mode.
 	commonStats.ServiceDetails, _ = analysis.RedactServiceDetails(commonStats.ServiceDetails)
 
 	stats := translateCommonStats(commonStats)

--- a/internal/processor/report_statistics_test.go
+++ b/internal/processor/report_statistics_test.go
@@ -1,0 +1,73 @@
+package processor
+
+import (
+	"testing"
+
+	"github.com/EvilBit-Labs/opnDossier/internal/analysis"
+	common "github.com/EvilBit-Labs/opnDossier/pkg/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func snmpServiceEntry(t *testing.T, stats *Statistics) *ServiceStatistics {
+	t.Helper()
+	for i := range stats.ServiceDetails {
+		if stats.ServiceDetails[i].Name == analysis.ServiceNameSNMP {
+			return &stats.ServiceDetails[i]
+		}
+	}
+	return nil
+}
+
+func TestGenerateStatistics_RedactsSNMPCommunity(t *testing.T) {
+	t.Parallel()
+
+	cfg := &common.CommonDevice{
+		SNMP: common.SNMPConfig{
+			ROCommunity: "super-secret-community",
+			SysLocation: "datacenter-1",
+			SysContact:  "admin@example.com",
+		},
+	}
+
+	stats := generateStatistics(cfg)
+
+	snmp := snmpServiceEntry(t, stats)
+	require.NotNil(t, snmp, "expected an SNMP service entry")
+	assert.Equal(t, "[REDACTED]", snmp.Details["community"])
+	assert.NotContains(t, snmp.Details["community"], "super-secret")
+	// Non-sensitive details survive.
+	assert.Equal(t, "datacenter-1", snmp.Details["location"])
+}
+
+func TestGenerateStatistics_NoSNMPService(t *testing.T) {
+	t.Parallel()
+
+	stats := generateStatistics(&common.CommonDevice{})
+
+	assert.Nil(t, snmpServiceEntry(t, stats), "no SNMP entry expected when ROCommunity is empty")
+}
+
+func TestGenerateStatistics_IDSFieldsPopulatedAlongsideRedaction(t *testing.T) {
+	t.Parallel()
+
+	// Guards the reorder in U3: redaction now happens before translate, IDS
+	// fields are still added after translate.
+	cfg := &common.CommonDevice{
+		SNMP: common.SNMPConfig{ROCommunity: "secret"},
+		IDS: &common.IDSConfig{
+			Enabled:    true,
+			IPSMode:    true,
+			Interfaces: []string{"wan"},
+		},
+	}
+
+	stats := generateStatistics(cfg)
+
+	assert.True(t, stats.IDSEnabled)
+	assert.Equal(t, "IPS (Prevention)", stats.IDSMode)
+	assert.Equal(t, []string{"wan"}, stats.IDSMonitoredInterfaces)
+	snmp := snmpServiceEntry(t, stats)
+	require.NotNil(t, snmp)
+	assert.Equal(t, "[REDACTED]", snmp.Details["community"])
+}

--- a/internal/sanitizer/rules.go
+++ b/internal/sanitizer/rules.go
@@ -338,8 +338,8 @@ func builtinRules() []Rule {
 				"tls_crypt", "tls_auth",
 				// SNMPv3 privacy/encryption key from the OPNsense net-snmp
 				// plugin (<OPNsense><netsnmp><user><enckey>). The bare "key"
-				// pattern above is exact-match only, so "enckey" needs its own
-				// alias. See GOTCHAS §11.3 and ADR-0001.
+				// pattern above is exact-match only (see exactMatchPatterns),
+				// so "enckey" needs its own substring alias. See ADR-0001.
 				"enckey", "enc_key",
 			},
 			ValueDetector: IsPrivateKey,

--- a/internal/sanitizer/rules.go
+++ b/internal/sanitizer/rules.go
@@ -336,6 +336,11 @@ func builtinRules() []Rule {
 				"openvpn.tls", "openvpn-server.tls", "openvpn-client.tls",
 				"openvpn.statickeys", "statickeys",
 				"tls_crypt", "tls_auth",
+				// SNMPv3 privacy/encryption key from the OPNsense net-snmp
+				// plugin (<OPNsense><netsnmp><user><enckey>). The bare "key"
+				// pattern above is exact-match only, so "enckey" needs its own
+				// alias. See GOTCHAS §11.3 and ADR-0001.
+				"enckey", "enc_key",
 			},
 			ValueDetector: IsPrivateKey,
 			Redactor: func(_ *Mapper, _, _ string) string {

--- a/internal/sanitizer/sanitizer_test.go
+++ b/internal/sanitizer/sanitizer_test.go
@@ -351,8 +351,15 @@ func TestSanitizeXML_SNMPv3Password(t *testing.T) {
 			if err := s.SanitizeXML(strings.NewReader(xml), &output); err != nil {
 				t.Fatalf("SanitizeXML() error = %v", err)
 			}
-			if strings.Contains(output.String(), passwordBody) {
-				t.Errorf("mode=%q leaked SNMPv3 auth password: %s", mode, output.String())
+			result := output.String()
+			if strings.Contains(result, passwordBody) {
+				t.Errorf("mode=%q leaked SNMPv3 auth password: %s", mode, result)
+			}
+			// Assert the marker is present, not just that the cleartext is
+			// absent — catches the node being dropped/rewritten instead of
+			// redacted.
+			if !strings.Contains(result, "[REDACTED-PASSWORD]") {
+				t.Errorf("mode=%q missing password redaction marker: %s", mode, result)
 			}
 		})
 	}

--- a/internal/sanitizer/sanitizer_test.go
+++ b/internal/sanitizer/sanitizer_test.go
@@ -289,6 +289,75 @@ func TestSanitizeXML_OpenVPNStaticKey(t *testing.T) {
 	}
 }
 
+// TestSanitizeXML_SNMPv3EncKey verifies the OPNsense net-snmp plugin's
+// SNMPv3 privacy/encryption key (<enckey>) is redacted. Before ADR-0001's fix
+// the bare "key" pattern was exact-match only, so <enckey> leaked in cleartext
+// through the raw-XML sanitize path.
+func TestSanitizeXML_SNMPv3EncKey(t *testing.T) {
+	const encKeyBody = "s3cr3t-privacy-key-value"
+
+	fixtures := []struct {
+		name string
+		xml  string
+	}{
+		{
+			name: "netsnmp_enckey",
+			xml: "<opnsense><OPNsense><netsnmp><user><users><user><enckey>" +
+				encKeyBody +
+				"</enckey></user></users></user></netsnmp></OPNsense></opnsense>",
+		},
+		{
+			name: "enc_key_alias",
+			xml: "<opnsense><OPNsense><netsnmp><user><users><user><enc_key>" +
+				encKeyBody +
+				"</enc_key></user></users></user></netsnmp></OPNsense></opnsense>",
+		},
+	}
+
+	for _, mode := range ValidModes() {
+		for _, fx := range fixtures {
+			t.Run(string(mode)+"_"+fx.name, func(t *testing.T) {
+				s := NewSanitizer(mode)
+				var output bytes.Buffer
+				if err := s.SanitizeXML(strings.NewReader(fx.xml), &output); err != nil {
+					t.Fatalf("SanitizeXML() error = %v", err)
+				}
+				result := output.String()
+				if strings.Contains(result, encKeyBody) {
+					t.Errorf("mode=%q fixture=%q leaked SNMPv3 enckey: %s", mode, fx.name, result)
+				}
+				if !strings.Contains(result, "[REDACTED-PRIVATE-KEY]") {
+					t.Errorf("mode=%q fixture=%q missing redaction marker: %s", mode, fx.name, result)
+				}
+			})
+		}
+	}
+}
+
+// TestSanitizeXML_SNMPv3Password verifies the net-snmp plugin's SNMPv3 auth
+// passphrase (<password>) is redacted via the generic password rule — guards
+// against an accidental rule reshuffle when the enckey alias was added.
+func TestSanitizeXML_SNMPv3Password(t *testing.T) {
+	const passwordBody = "s3cr3t-auth-passphrase"
+
+	xml := "<opnsense><OPNsense><netsnmp><user><users><user><password>" +
+		passwordBody +
+		"</password></user></users></user></netsnmp></OPNsense></opnsense>"
+
+	for _, mode := range ValidModes() {
+		t.Run(string(mode), func(t *testing.T) {
+			s := NewSanitizer(mode)
+			var output bytes.Buffer
+			if err := s.SanitizeXML(strings.NewReader(xml), &output); err != nil {
+				t.Fatalf("SanitizeXML() error = %v", err)
+			}
+			if strings.Contains(output.String(), passwordBody) {
+				t.Errorf("mode=%q leaked SNMPv3 auth password: %s", mode, output.String())
+			}
+		})
+	}
+}
+
 // TestSanitizeXML_OpenVPN_TLS_NoFalsePositives guards against over-broad
 // redaction of the `tls` substring. The <tls> wrapper on Suricata eveLog
 // and the <tls> log-level enum under the IPsec strongSwan daemon syslog


### PR DESCRIPTION
## Summary

Deduplicates the two divergent implementations of SNMP `ServiceDetails` redaction (processor + converter) into one shared, non-mutating primitive, and closes a latent cleartext-secret leak in the `sanitize` command discovered during the work. The dedup is behavior-neutral; the leak fix is a net security improvement.

Resolves NATS-163.

## What changed

- **`refactor`: deduplicate SNMP redaction (NATS-163).** New `analysis.RedactServiceDetails` primitive plus a centralized sensitive-key list. The processor redacts the shared `common.Statistics` before translating into its own type (removing the duplicated in-place redactor); the converter preserves its non-mutating memoization contract by delegating to the same primitive. A convergence test pins that both paths produce identical `ServiceDetails` redaction for the same input. The redaction marker stays `[REDACTED]`, so there is no rendered-output change.
- **`fix`: redact SNMPv3 `enckey`.** `opnDossier sanitize` walks raw XML element names; `<password>` was caught by the generic `pass` match, but `<enckey>` — the SNMPv3 privacy/encryption key persisted by the OPNsense net-snmp plugin — matched no pattern (the `private_key` rule exact-matches `"key"` only). Added `enckey`/`enc_key` to the `private_key` rule, closing a cleartext privacy-key leak, with a regression test.
- **`docs`: ADR-0001.** Records the verified OPNsense/pfSense SNMP configuration storage model (where SNMP credentials live across core `bsnmpd`, the net-snmp plugin, and pfSense), checked against upstream vendor source.
- **`ci`: mdformat hook fix.** The `mdformat` pre-commit hook failed repo-wide because `.mdformat.toml`'s `exclude` feature requires the hook to run on Python 3.13+, while pre-commit builds the hook venv on its own interpreter (3.11). Moved the exclusions to pre-commit's native, version-independent `exclude:` regex.
- **`test`: strengthen the SNMPv3 password assertion** to also verify the redaction marker is present, not just that the cleartext is absent (from CodeRabbit review).
- Also carries a pre-existing `chore(settings)` commit removing plugin configuration from `.claude/settings.json`.

## Deferred to a separate epic

Full SNMPv3 **ingestion + redaction** is out of scope here: it requires first parsing the OPNsense `<OPNsense><netsnmp>` plugin namespace (a new schema surface) that opnDossier does not parse today, and pfSense base has no SNMPv3. The dedup's centralized key list makes adding the SNMPv3 key a one-line change once ingestion lands. Rationale and verified field names are in `docs/adr/0001-opnsense-pfsense-snmp-config-storage-model.md`.

## Test plan

- [x] `just ci-check` green (format, lint, full test suite)
- [x] `go test ./...` — 35 packages ok
- [x] `go test -race` on analysis / converter / processor / sanitizer
- [x] Convergence test pins processor ↔ converter redaction equivalence
- [x] Regression tests: `sanitize` redacts `<enckey>` and the SNMPv3 `<password>`
- [x] No golden / audit fixture changes (behavior-neutral dedup)

## AI usage

Used Claude Code (`Claude Opus 4.8`) to implement and document this change. All code was reviewed and tested locally (`just ci-check`, `go test -race`, `golangci-lint`) and run through a CodeRabbit review pass. See [AI_POLICY.md](AI_POLICY.md).
