### PR TITLE
feat(audit): shared detection engine + blue-mode analysis (slice 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -241,3 +241,4 @@ internal/sanitizer/testdata/benchmark-10mb.xml
 
 **/*.local.yaml
 .claude/skills
+.dosu/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,3 +101,16 @@ When documenting interfaces in prose, Mermaid diagrams, or code examples:
 ### Post-Push CI Monitoring
 
 After any successful `git push`, immediately invoke the `github-action-monitor` skill to monitor the triggered GitHub Actions workflow runs and report pass/fail. Do not wait to be asked — this is part of the push workflow.
+
+<!-- dosu:mcp:start v1 -->
+
+## Dosu
+
+Shared team knowledge lives in [Dosu](https://dosu.dev), via the Dosu MCP server.
+
+- Before a task, and for any codebase or docs questions: pull context with `read_knowledge` before digging through source.
+- After a task: save durable learnings with `write_knowledge`.
+
+Missing these tools? Run `dosu setup --help` — it covers agent-assisted setup.
+
+<!-- dosu:mcp:end -->

--- a/internal/analysis/detect.go
+++ b/internal/analysis/detect.go
@@ -197,8 +197,8 @@ func DetectSecurityIssues(cfg *common.CommonDevice) []common.SecurityFinding {
 	}
 
 	for i, rule := range cfg.FirewallRules {
-		if rule.Type == common.RuleTypePass && rule.Source.Address == constants.NetworkAny &&
-			slices.Contains(rule.Interfaces, "wan") {
+		if !rule.Disabled && rule.Type == common.RuleTypePass && rule.Source.Address == constants.NetworkAny &&
+			RuleReachability(rule, cfg.Interfaces) == WANReachable {
 			findings = append(findings, common.SecurityFinding{
 				Component:      fmt.Sprintf("filter.rule[%d]", i),
 				Issue:          "Overly Permissive WAN Rule",

--- a/internal/analysis/detect_test.go
+++ b/internal/analysis/detect_test.go
@@ -580,6 +580,26 @@ func TestDetectSecurityIssues(t *testing.T) {
 			},
 			wantCount: 0,
 		},
+		{
+			// Covers AE5 / U1 consolidation: the pre-consolidation exact-match
+			// WAN check (`slices.Contains(rule.Interfaces, "wan")`) misses
+			// multi-WAN interfaces like "wan2". This is the regression test
+			// pinning the fix to route through the canonical
+			// analysis.RuleReachability helper instead.
+			name: "wan2 permissive rule is detected (multi-WAN)",
+			cfg: &common.CommonDevice{
+				FirewallRules: []common.FirewallRule{
+					{
+						Type:       common.RuleTypePass,
+						Interfaces: []string{"wan2"},
+						Source:     common.RuleEndpoint{Address: "any"},
+					},
+				},
+			},
+			wantCount:      1,
+			wantIssues:     []string{"Overly Permissive WAN Rule"},
+			wantSeverities: []common.Severity{common.SeverityHigh},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/analysis/engine.go
+++ b/internal/analysis/engine.go
@@ -1,0 +1,261 @@
+package analysis
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/EvilBit-Labs/opnDossier/internal/constants"
+	common "github.com/EvilBit-Labs/opnDossier/pkg/model"
+)
+
+// weakCipherTokens lists cipher/protocol substrings that indicate a legacy,
+// broken, or otherwise weak TLS cipher configuration. Matching is
+// case-insensitive substring search against the configured OpenSSL cipher
+// string.
+var weakCipherTokens = []string{"RC4", "DES", "3DES", "MD5", "NULL", "EXPORT"}
+
+// weakTLSProtocols lists TLS/DTLS protocol-version floors considered
+// insecure by current guidance (TLS 1.0/1.1 and all SSL versions).
+var weakTLSProtocols = []string{"SSLv3", "SSLv2", "TLSv1", "TLSv1.1"}
+
+// ScanObservations runs the shared detection engine over cfg and returns a
+// flat, neutral list of Observations: the existing DetectSecurityIssues
+// detections wrapped with reachability and confidence, plus additive
+// framework-free hygiene detectors for categories no compliance plugin owns
+// at per-instance granularity (insecure management protocols, weak crypto
+// defaults, any-to-any rules, disabled logging).
+//
+// ScanObservations does not modify DetectSecurityIssues or ComputeAnalysis;
+// both remain unchanged for their existing callers in internal/converter and
+// internal/processor (KTD3, R4). Returns nil for a nil cfg.
+func ScanObservations(cfg *common.CommonDevice) []Observation {
+	if cfg == nil {
+		return nil
+	}
+
+	observations := adaptSecurityFindings(DetectSecurityIssues(cfg))
+	observations = append(observations, detectInsecureManagementProtocols(cfg)...)
+	observations = append(observations, detectWeakCryptoDefaults(cfg)...)
+	observations = append(observations, detectAnyToAnyRules(cfg)...)
+	observations = append(observations, detectDisabledLogging(cfg)...)
+
+	return observations
+}
+
+// adaptSecurityFindings wraps the existing DetectSecurityIssues output into
+// Observations without altering DetectSecurityIssues itself (KTD3). Every
+// existing detection is deterministic pattern matching against config
+// fields, so confidence is High.
+func adaptSecurityFindings(findings []common.SecurityFinding) []Observation {
+	observations := make([]Observation, 0, len(findings))
+
+	for _, f := range findings {
+		observations = append(observations, Observation{
+			Severity:       Severity(f.Severity),
+			Confidence:     ConfidenceHigh,
+			Reachability:   securityFindingReachability(f),
+			Component:      f.Component,
+			Evidence:       f.Description,
+			Title:          f.Issue,
+			Description:    f.Description,
+			Recommendation: f.Recommendation,
+		})
+	}
+
+	return observations
+}
+
+// securityFindingReachability derives a reachability tag for a
+// DetectSecurityIssues finding.
+//
+// The only per-instance-rule finding DetectSecurityIssues currently emits is
+// the permissive WAN pass rule (Component "filter.rule[N]"), and that
+// detector already requires the rule to be bound to a WAN interface (via
+// RuleReachability as of the U1 consolidation), so it is deterministically
+// WAN-reachable. System-wide findings (insecure WebGUI protocol, default
+// SNMP community) are not bound to a specific interface, and correlating
+// them against exposing firewall/NAT rules is red mode's WAN-exposed-service
+// enumeration (R17), out of scope for this slice — so they are tagged Local
+// here rather than guessed.
+func securityFindingReachability(f common.SecurityFinding) Reachability {
+	if strings.HasPrefix(f.Component, "filter.rule[") {
+		return WANReachable
+	}
+
+	return Local
+}
+
+// detectInsecureManagementProtocols flags SNMP v1/v2c community-based
+// authentication as an insecure management protocol family, independent of
+// whether the configured community string happens to be the well-known
+// default ("public", already covered by DetectSecurityIssues). SNMP v1/v2c
+// transmits its community string in cleartext regardless of the string's
+// value, so any configured RO community is a distinct, additive hygiene
+// concern.
+func detectInsecureManagementProtocols(cfg *common.CommonDevice) []Observation {
+	if cfg.SNMP.ROCommunity == "" {
+		return nil
+	}
+
+	return []Observation{
+		{
+			Severity:       SeverityMedium,
+			Confidence:     ConfidenceHigh,
+			Reachability:   Local,
+			Component:      "snmpd.protocol",
+			Evidence:       "snmp community-based authentication (v1/v2c) configured",
+			Title:          "Insecure Management Protocol: SNMP v1/v2c",
+			Description:    "SNMP is configured with community-string authentication (v1/v2c), which transmits credentials in cleartext regardless of the community string value.",
+			Recommendation: "Migrate to SNMPv3 with authentication and privacy (authPriv), or disable SNMP if not required.",
+		},
+	}
+}
+
+// detectWeakCryptoDefaults flags legacy/weak TLS cipher strings or minimum
+// protocol versions configured in the device's system-wide trust settings.
+func detectWeakCryptoDefaults(cfg *common.CommonDevice) []Observation {
+	if cfg.Trust == nil {
+		return nil
+	}
+
+	var observations []Observation
+
+	// containsWeakCipherToken is a plain substring match against the
+	// OpenSSL cipher string. It does not parse OpenSSL cipher-list grammar
+	// (e.g. a leading "!" excludes a cipher class rather than including
+	// it), so a string that *excludes* a weak class (like "!aNULL") can
+	// still match the "NULL" substring. Confidence is Medium rather than
+	// High to reflect that known limitation; the observation is still
+	// always surfaced per R6 (confidence never gates a match).
+	if token, ok := containsWeakCipherToken(cfg.Trust.CipherString); ok {
+		observations = append(observations, Observation{
+			Severity:     SeverityMedium,
+			Confidence:   ConfidenceMedium,
+			Reachability: Local,
+			Component:    "trust.cipherstring",
+			Evidence:     fmt.Sprintf("cipherString contains weak token %q", token),
+			Title:        "Weak Crypto Default: Legacy TLS Cipher",
+			Description: fmt.Sprintf(
+				"The system-wide TLS cipher string includes the legacy/weak cipher token %q.",
+				token,
+			),
+			Recommendation: "Remove legacy cipher tokens (RC4, DES, 3DES, MD5, NULL, EXPORT) from the OpenSSL cipher string.",
+		})
+	}
+
+	if slicesContainsFold(weakTLSProtocols, cfg.Trust.MinProtocol) {
+		observations = append(observations, Observation{
+			Severity:     SeverityMedium,
+			Confidence:   ConfidenceHigh,
+			Reachability: Local,
+			Component:    "trust.minprotocol",
+			Evidence:     "minProtocol=" + cfg.Trust.MinProtocol,
+			Title:        "Weak Crypto Default: Legacy TLS Protocol Floor",
+			Description: fmt.Sprintf(
+				"The minimum TLS protocol version is set to %s, a deprecated/insecure protocol version.",
+				cfg.Trust.MinProtocol,
+			),
+			Recommendation: "Set the minimum TLS protocol version to TLSv1.2 or higher.",
+		})
+	}
+
+	return observations
+}
+
+// containsWeakCipherToken reports whether cipherString contains any known
+// weak-cipher token, returning the matched token for use in the finding
+// description.
+func containsWeakCipherToken(cipherString string) (string, bool) {
+	if cipherString == "" {
+		return "", false
+	}
+
+	upper := strings.ToUpper(cipherString)
+	for _, token := range weakCipherTokens {
+		if strings.Contains(upper, token) {
+			return token, true
+		}
+	}
+
+	return "", false
+}
+
+// slicesContainsFold reports whether value case-insensitively matches any
+// entry in candidates.
+func slicesContainsFold(candidates []string, value string) bool {
+	if value == "" {
+		return false
+	}
+
+	for _, c := range candidates {
+		if strings.EqualFold(c, value) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// detectAnyToAnyRules flags enabled pass rules with source, destination,
+// port, and protocol all set to "any" — one Observation per matching rule.
+// This mirrors the firewall compliance plugin's FIREWALL-022 control at
+// per-rule granularity: the plugin control reports a single pass/fail for
+// the whole device, while this hygiene detector identifies which specific
+// rule(s) are the smell so blue can point at the exact config element.
+func detectAnyToAnyRules(cfg *common.CommonDevice) []Observation {
+	var observations []Observation
+
+	for i, rule := range cfg.FirewallRules {
+		if rule.Disabled || rule.Type != common.RuleTypePass {
+			continue
+		}
+
+		srcAny := rule.Source.Address == constants.NetworkAny
+		dstAny := rule.Destination.Address == constants.NetworkAny
+		portAny := rule.Destination.Port == "" || rule.Destination.Port == constants.NetworkAny
+		protoAny := rule.Protocol == "" || strings.EqualFold(rule.Protocol, constants.NetworkAny)
+
+		if !srcAny || !dstAny || !portAny || !protoAny {
+			continue
+		}
+
+		component := fmt.Sprintf("filter.rule[%d]", i)
+		observations = append(observations, Observation{
+			Severity:     SeverityHigh,
+			Confidence:   ConfidenceHigh,
+			Reachability: RuleReachability(rule, cfg.Interfaces),
+			Component:    component,
+			Evidence:     fmt.Sprintf("rule %d: source=any destination=any port=any protocol=any", i+1),
+			Title:        "Any-to-Any Pass Rule",
+			Description: fmt.Sprintf(
+				"Rule %d passes traffic with source, destination, port, and protocol all set to any.",
+				i+1,
+			),
+			Recommendation: "Replace any-any rules with specific source/destination/port/protocol restrictions.",
+		})
+	}
+
+	return observations
+}
+
+// detectDisabledLogging flags remote syslog forwarding that is enabled but
+// does not include firewall filter log messages, meaning allowed/denied
+// traffic decisions are not captured in the forwarded log stream.
+func detectDisabledLogging(cfg *common.CommonDevice) []Observation {
+	if !cfg.Syslog.Enabled || cfg.Syslog.FilterLogging {
+		return nil
+	}
+
+	return []Observation{
+		{
+			Severity:       SeverityMedium,
+			Confidence:     ConfidenceHigh,
+			Reachability:   Local,
+			Component:      "syslog.filterlogging",
+			Evidence:       "syslog.enabled=true syslog.filterLogging=false",
+			Title:          "Disabled Logging: Firewall Filter Events Not Forwarded",
+			Description:    "Remote syslog forwarding is enabled, but firewall filter log messages are not included, so allow/deny decisions are not captured off-box.",
+			Recommendation: "Enable filter logging under the remote syslog configuration so firewall decisions are forwarded.",
+		},
+	}
+}

--- a/internal/analysis/engine_test.go
+++ b/internal/analysis/engine_test.go
@@ -1,0 +1,329 @@
+package analysis_test
+
+import (
+	"testing"
+
+	"github.com/EvilBit-Labs/opnDossier/internal/analysis"
+	common "github.com/EvilBit-Labs/opnDossier/pkg/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestScanObservations_NilDevice covers the nil-safety contract shared by
+// the rest of the analysis package.
+func TestScanObservations_NilDevice(t *testing.T) {
+	t.Parallel()
+
+	assert.Nil(t, analysis.ScanObservations(nil))
+}
+
+// TestScanObservations_PreservesExistingDetections asserts that the three
+// existing DetectSecurityIssues detections (insecure WebGUI HTTP, default
+// SNMP community, permissive WAN pass rule) are wrapped into Observations
+// with reachability and confidence populated (U3 test scenario 1, R4).
+func TestScanObservations_PreservesExistingDetections(t *testing.T) {
+	t.Parallel()
+
+	cfg := &common.CommonDevice{
+		System: common.System{
+			WebGUI: common.WebGUI{Protocol: "http"},
+		},
+		SNMP: common.SNMPConfig{ROCommunity: "public"},
+		FirewallRules: []common.FirewallRule{
+			{
+				Type:       common.RuleTypePass,
+				Interfaces: []string{"wan"},
+				Source:     common.RuleEndpoint{Address: "any"},
+			},
+		},
+	}
+
+	observations := analysis.ScanObservations(cfg)
+
+	byTitle := make(map[string]analysis.Observation, len(observations))
+	for _, o := range observations {
+		byTitle[o.Title] = o
+	}
+
+	webgui, ok := byTitle["Insecure Web GUI Protocol"]
+	require.True(t, ok, "expected wrapped Insecure Web GUI Protocol observation")
+	assert.Equal(t, analysis.SeverityCritical, webgui.Severity)
+	assert.Equal(t, analysis.ConfidenceHigh, webgui.Confidence)
+	assert.Equal(t, "system.webgui.protocol", webgui.Component)
+
+	snmp, ok := byTitle["Default SNMP Community String"]
+	require.True(t, ok, "expected wrapped Default SNMP Community String observation")
+	assert.Equal(t, analysis.SeverityHigh, snmp.Severity)
+	assert.Equal(t, analysis.ConfidenceHigh, snmp.Confidence)
+
+	wanRule, ok := byTitle["Overly Permissive WAN Rule"]
+	require.True(t, ok, "expected wrapped Overly Permissive WAN Rule observation")
+	assert.Equal(t, analysis.SeverityHigh, wanRule.Severity)
+	assert.Equal(t, analysis.WANReachable, wanRule.Reachability, "WAN pass rule finding must be tagged WAN-reachable")
+	assert.Equal(t, analysis.ConfidenceHigh, wanRule.Confidence)
+}
+
+// TestDetectInsecureManagementProtocols covers the "fires on crafted config,
+// silent on clean config" scenario for the insecure-management-protocols
+// hygiene category.
+func TestDetectInsecureManagementProtocols(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		cfg       *common.CommonDevice
+		wantCount int
+	}{
+		{
+			name:      "any configured SNMP community fires, not just the default",
+			cfg:       &common.CommonDevice{SNMP: common.SNMPConfig{ROCommunity: "notpublic"}},
+			wantCount: 1,
+		},
+		{
+			name:      "no SNMP community configured stays silent",
+			cfg:       &common.CommonDevice{},
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			observations := analysis.ScanObservations(tt.cfg)
+
+			count := 0
+			for _, o := range observations {
+				if o.Component == "snmpd.protocol" {
+					count++
+				}
+			}
+
+			assert.Equal(t, tt.wantCount, count)
+		})
+	}
+}
+
+// TestDetectWeakCryptoDefaults covers the weak-crypto-defaults hygiene
+// category: fires on a crafted config, stays silent on a clean one.
+func TestDetectWeakCryptoDefaults(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		cfg       *common.CommonDevice
+		wantCount int
+	}{
+		{
+			name:      "nil trust config stays silent",
+			cfg:       &common.CommonDevice{},
+			wantCount: 0,
+		},
+		{
+			name: "clean trust config stays silent",
+			cfg: &common.CommonDevice{
+				Trust: &common.TrustConfig{CipherString: "ECDHE+AESGCM:ECDHE+AES256", MinProtocol: "TLSv1.2"},
+			},
+			wantCount: 0,
+		},
+		{
+			name: "weak cipher token fires",
+			cfg: &common.CommonDevice{
+				Trust: &common.TrustConfig{CipherString: "RC4-SHA:HIGH"},
+			},
+			wantCount: 1,
+		},
+		{
+			name: "weak minimum protocol fires",
+			cfg: &common.CommonDevice{
+				Trust: &common.TrustConfig{MinProtocol: "TLSv1"},
+			},
+			wantCount: 1,
+		},
+		{
+			name: "both weak cipher and weak protocol fire two observations",
+			cfg: &common.CommonDevice{
+				Trust: &common.TrustConfig{CipherString: "DES-CBC3-SHA", MinProtocol: "TLSv1.1"},
+			},
+			wantCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			observations := analysis.ScanObservations(tt.cfg)
+
+			count := 0
+			for _, o := range observations {
+				if o.Component == "trust.cipherstring" || o.Component == "trust.minprotocol" {
+					count++
+				}
+			}
+
+			assert.Equal(t, tt.wantCount, count)
+		})
+	}
+}
+
+// TestDetectAnyToAnyRules covers the any-to-any-rules hygiene category,
+// including per-rule granularity and reachability tagging.
+func TestDetectAnyToAnyRules(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		cfg       *common.CommonDevice
+		wantCount int
+	}{
+		{
+			name:      "no rules stays silent",
+			cfg:       &common.CommonDevice{},
+			wantCount: 0,
+		},
+		{
+			name: "specific rule stays silent",
+			cfg: &common.CommonDevice{
+				FirewallRules: []common.FirewallRule{
+					{
+						Type:        common.RuleTypePass,
+						Interfaces:  []string{"lan"},
+						Source:      common.RuleEndpoint{Address: "any"},
+						Destination: common.RuleEndpoint{Address: "192.168.1.10", Port: "443"},
+						Protocol:    "tcp",
+					},
+				},
+			},
+			wantCount: 0,
+		},
+		{
+			name: "any-to-any pass rule fires",
+			cfg: &common.CommonDevice{
+				FirewallRules: []common.FirewallRule{
+					{
+						Type:        common.RuleTypePass,
+						Interfaces:  []string{"lan"},
+						Source:      common.RuleEndpoint{Address: "any"},
+						Destination: common.RuleEndpoint{Address: "any"},
+					},
+				},
+			},
+			wantCount: 1,
+		},
+		{
+			name: "disabled any-to-any rule stays silent",
+			cfg: &common.CommonDevice{
+				FirewallRules: []common.FirewallRule{
+					{
+						Type:        common.RuleTypePass,
+						Interfaces:  []string{"lan"},
+						Source:      common.RuleEndpoint{Address: "any"},
+						Destination: common.RuleEndpoint{Address: "any"},
+						Disabled:    true,
+					},
+				},
+			},
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			observations := analysis.ScanObservations(tt.cfg)
+
+			count := 0
+			for _, o := range observations {
+				if o.Title == "Any-to-Any Pass Rule" {
+					count++
+				}
+			}
+
+			assert.Equal(t, tt.wantCount, count)
+		})
+	}
+}
+
+// TestDetectDisabledLogging covers the disabled-logging hygiene category.
+func TestDetectDisabledLogging(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		cfg       *common.CommonDevice
+		wantCount int
+	}{
+		{
+			name:      "syslog disabled stays silent",
+			cfg:       &common.CommonDevice{},
+			wantCount: 0,
+		},
+		{
+			name: "syslog enabled with filter logging stays silent",
+			cfg: &common.CommonDevice{
+				Syslog: common.SyslogConfig{Enabled: true, FilterLogging: true},
+			},
+			wantCount: 0,
+		},
+		{
+			name: "syslog enabled without filter logging fires",
+			cfg: &common.CommonDevice{
+				Syslog: common.SyslogConfig{Enabled: true, FilterLogging: false},
+			},
+			wantCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			observations := analysis.ScanObservations(tt.cfg)
+
+			count := 0
+			for _, o := range observations {
+				if o.Component == "syslog.filterlogging" {
+					count++
+				}
+			}
+
+			assert.Equal(t, tt.wantCount, count)
+		})
+	}
+}
+
+// TestScanObservations_ExportPathUnaffected pins that ComputeAnalysis (the
+// export-enrichment path consumed by internal/converter/enrichment.go and
+// internal/processor/analyze.go) is unaffected by the shared engine's
+// additive hygiene detectors — ScanObservations is a separate code path that
+// wraps, not replaces, DetectSecurityIssues (R4).
+func TestScanObservations_ExportPathUnaffected(t *testing.T) {
+	t.Parallel()
+
+	cfg := &common.CommonDevice{
+		SNMP:  common.SNMPConfig{ROCommunity: "notpublic"},
+		Trust: &common.TrustConfig{CipherString: "RC4-SHA"},
+		FirewallRules: []common.FirewallRule{
+			{
+				Type:        common.RuleTypePass,
+				Interfaces:  []string{"lan"},
+				Source:      common.RuleEndpoint{Address: "any"},
+				Destination: common.RuleEndpoint{Address: "any"},
+			},
+		},
+		Syslog: common.SyslogConfig{Enabled: true},
+	}
+
+	// The new hygiene detectors fire on this config (sanity check that the
+	// fixture actually exercises them).
+	observations := analysis.ScanObservations(cfg)
+	assert.NotEmpty(t, observations)
+
+	// ComputeAnalysis / DetectSecurityIssues must be unaffected: this config
+	// has no insecure WebGUI, no default SNMP community, and no permissive
+	// WAN rule, so DetectSecurityIssues must still report zero findings.
+	analysisResult := analysis.ComputeAnalysis(cfg)
+	assert.Empty(t, analysisResult.SecurityIssues)
+}

--- a/internal/analysis/observation.go
+++ b/internal/analysis/observation.go
@@ -1,0 +1,85 @@
+package analysis
+
+import "slices"
+
+// Confidence represents how confident the shared detection engine is that an
+// Observation reflects a real, actionable condition. Confidence never gates
+// whether an observation is surfaced — every match is reported regardless of
+// its confidence label; confidence is presentation metadata only.
+type Confidence string
+
+// Confidence level constants define the three-level confidence scale shared
+// by observations, blue hygiene findings, and red findings.
+const (
+	// ConfidenceHigh indicates a deterministic, low-false-positive detection.
+	ConfidenceHigh Confidence = "high"
+	// ConfidenceMedium indicates a detection with plausible false positives.
+	ConfidenceMedium Confidence = "medium"
+	// ConfidenceLow indicates a heuristic detection with a higher false-positive rate.
+	ConfidenceLow Confidence = "low"
+)
+
+// ValidConfidences returns a fresh copy of all valid confidence values.
+// Returns a new slice each call to prevent callers from mutating shared state.
+func ValidConfidences() []Confidence {
+	return []Confidence{ConfidenceHigh, ConfidenceMedium, ConfidenceLow}
+}
+
+// String returns the string representation of the confidence level.
+func (c Confidence) String() string {
+	return string(c)
+}
+
+// IsValidConfidence checks whether the given confidence is a recognized value.
+func IsValidConfidence(c Confidence) bool {
+	return slices.Contains(ValidConfidences(), c)
+}
+
+// Observation is a neutral, mode-agnostic detection produced by the shared
+// detection engine (ScanObservations). Blue and red audit modes are
+// presentation lenses over the same observations, so detection logic lives
+// here exactly once and the two modes cannot disagree about the underlying
+// facts. See docs/plans/2026-07-17-001-feat-audit-blue-red-analysis-plan.md.
+type Observation struct {
+	// Severity is the shared severity scale value (critical..info), aligned
+	// with the compliance-plugin severity vocabulary.
+	Severity Severity `json:"severity"`
+	// Confidence labels how certain the detection is; never used to drop an
+	// observation.
+	Confidence Confidence `json:"confidence"`
+	// Reachability tags where this observation is reachable from: WAN, LAN,
+	// or local only.
+	Reachability Reachability `json:"reachability"`
+	// Component identifies the originating configuration element (e.g.
+	// "filter.rule[3]", "system.webgui.protocol").
+	Component string `json:"component"`
+	// Evidence carries a human-readable pointer to the specific config value
+	// that triggered the observation.
+	Evidence string `json:"evidence,omitempty"`
+	// Title is a brief description of the observation.
+	Title string `json:"title"`
+	// Description provides detailed information about the observation.
+	Description string `json:"description"`
+	// Recommendation suggests how to address the observation.
+	Recommendation string `json:"recommendation"`
+}
+
+// ToFinding maps the observation into the canonical analysis.Finding shape
+// consumed by blue-mode hygiene rendering. analysis.Finding has no dedicated
+// confidence/reachability/evidence fields, so those three axes are carried
+// in Metadata rather than dropped.
+func (o Observation) ToFinding() Finding {
+	return Finding{
+		Type:           "hygiene",
+		Severity:       string(o.Severity),
+		Title:          o.Title,
+		Description:    o.Description,
+		Recommendation: o.Recommendation,
+		Component:      o.Component,
+		Metadata: map[string]string{
+			"confidence":   string(o.Confidence),
+			"reachability": string(o.Reachability),
+			"evidence":     o.Evidence,
+		},
+	}
+}

--- a/internal/analysis/observation_test.go
+++ b/internal/analysis/observation_test.go
@@ -1,0 +1,88 @@
+package analysis_test
+
+import (
+	"testing"
+
+	"github.com/EvilBit-Labs/opnDossier/internal/analysis"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestObservation_CarriesAllFourAxes covers U2's requirement that an
+// Observation carries severity, confidence, evidence, and reachability
+// (R1, R6).
+func TestObservation_CarriesAllFourAxes(t *testing.T) {
+	t.Parallel()
+
+	obs := analysis.Observation{
+		Severity:       analysis.SeverityHigh,
+		Confidence:     analysis.ConfidenceMedium,
+		Reachability:   analysis.WANReachable,
+		Component:      "filter.rule[3]",
+		Evidence:       "rule allows any source on wan",
+		Title:          "Overly Permissive WAN Rule",
+		Description:    "Rule 3 allows any source to pass traffic on WAN interface",
+		Recommendation: "Restrict source networks",
+	}
+
+	assert.Equal(t, analysis.SeverityHigh, obs.Severity)
+	assert.Equal(t, analysis.ConfidenceMedium, obs.Confidence)
+	assert.Equal(t, analysis.WANReachable, obs.Reachability)
+	assert.Equal(t, "filter.rule[3]", obs.Component)
+	assert.Equal(t, "rule allows any source on wan", obs.Evidence)
+	assert.Equal(t, "Overly Permissive WAN Rule", obs.Title)
+	assert.Equal(t, "Rule 3 allows any source to pass traffic on WAN interface", obs.Description)
+	assert.Equal(t, "Restrict source networks", obs.Recommendation)
+}
+
+// TestConfidence_RoundTrips covers the confidence label round-trip and
+// vocabulary requirement (R6).
+func TestConfidence_RoundTrips(t *testing.T) {
+	t.Parallel()
+
+	for _, c := range analysis.ValidConfidences() {
+		assert.True(t, analysis.IsValidConfidence(c))
+		assert.Equal(t, string(c), c.String())
+	}
+
+	assert.False(t, analysis.IsValidConfidence(analysis.Confidence("bogus")))
+}
+
+// TestValidSeverities_MatchSharedVocabulary pins that Observation reuses the
+// existing analysis.Severity vocabulary (KTD2) rather than introducing a
+// second severity type.
+func TestValidSeverities_MatchSharedVocabulary(t *testing.T) {
+	t.Parallel()
+
+	for _, s := range analysis.ValidSeverities() {
+		obs := analysis.Observation{Severity: s}
+		assert.True(t, analysis.IsValidSeverity(obs.Severity))
+	}
+}
+
+// TestObservation_ToFinding_PreservesSeverityComponentEvidence covers U2's
+// mapper test scenario: ToFinding preserves severity/component/evidence.
+func TestObservation_ToFinding_PreservesSeverityComponentEvidence(t *testing.T) {
+	t.Parallel()
+
+	obs := analysis.Observation{
+		Severity:       analysis.SeverityCritical,
+		Confidence:     analysis.ConfidenceHigh,
+		Reachability:   analysis.LANOnly,
+		Component:      "system.webgui.protocol",
+		Evidence:       "protocol=http",
+		Title:          "Insecure Web GUI Protocol",
+		Description:    "Web GUI is configured to use HTTP instead of HTTPS",
+		Recommendation: "Change web GUI protocol to HTTPS",
+	}
+
+	finding := obs.ToFinding()
+
+	assert.Equal(t, string(analysis.SeverityCritical), finding.Severity)
+	assert.Equal(t, "system.webgui.protocol", finding.Component)
+	assert.Equal(t, obs.Title, finding.Title)
+	assert.Equal(t, obs.Description, finding.Description)
+	assert.Equal(t, obs.Recommendation, finding.Recommendation)
+	assert.Equal(t, "protocol=http", finding.Metadata["evidence"])
+	assert.Equal(t, string(analysis.ConfidenceHigh), finding.Metadata["confidence"])
+	assert.Equal(t, string(analysis.LANOnly), finding.Metadata["reachability"])
+}

--- a/internal/analysis/reachability.go
+++ b/internal/analysis/reachability.go
@@ -1,0 +1,147 @@
+package analysis
+
+import (
+	"slices"
+	"strings"
+
+	common "github.com/EvilBit-Labs/opnDossier/pkg/model"
+)
+
+// Reachability describes where a firewall rule, interface, or NAT rule can be
+// reached from: the public internet (WAN), only from local/internal networks
+// (LAN), or nowhere on any network (Local — e.g. a disabled interface, or a
+// NAT rule with no matching enabled pass rule).
+type Reachability string
+
+const (
+	// WANReachable indicates the element is reachable from the WAN (internet).
+	WANReachable Reachability = "wan"
+	// LANOnly indicates the element is reachable only from LAN/internal networks.
+	LANOnly Reachability = "lan"
+	// Local indicates the element is not reachable from any network — for
+	// example a disabled interface, or a NAT rule with no matching enabled
+	// pass rule.
+	Local Reachability = "local"
+)
+
+// String returns the string representation of the reachability tag.
+func (r Reachability) String() string {
+	return string(r)
+}
+
+// IsWANInterfaceName reports whether name is a WAN-style interface name,
+// using case-insensitive "wan" prefix matching (e.g. "wan", "WAN", "wan2").
+//
+// This is the single canonical WAN-interface-name predicate in the codebase.
+// internal/plugins/sans, internal/plugins/firewall, and the rest of
+// internal/analysis all route through this function instead of
+// reimplementing the check — see GOTCHAS.md and the reachability
+// consolidation history for why the two previously-divergent exact-match
+// sites in this package were bugs, not just duplication.
+//
+// Known limitation: detection is name-prefix-only. A secondary internet uplink
+// left with its default logical name (e.g. "opt1") rather than renamed to a
+// "wan"-prefixed name is classified LAN-only, so a service exposed on it can be
+// under-reported. Closing this requires consulting gateway/default-route
+// signals (common.Gateway.Interface) and is tracked as follow-up work, not
+// addressed by this consolidation.
+func IsWANInterfaceName(name string) bool {
+	return strings.HasPrefix(strings.ToLower(name), "wan")
+}
+
+// isLoopbackInterfaceName reports whether name looks like a loopback
+// interface (e.g. "lo0"). Loopback interfaces are never reachable from a
+// network and are classified as Local.
+func isLoopbackInterfaceName(name string) bool {
+	lower := strings.ToLower(name)
+	return lower == "lo" || strings.HasPrefix(lower, "lo0")
+}
+
+// InterfaceReachability classifies a single interface as WAN-reachable,
+// LAN-only, or local, based on its administrative state and name.
+func InterfaceReachability(iface common.Interface) Reachability {
+	if !iface.Enabled || isLoopbackInterfaceName(iface.Name) {
+		return Local
+	}
+
+	if IsWANInterfaceName(iface.Name) {
+		return WANReachable
+	}
+
+	return LANOnly
+}
+
+// RuleReachability classifies a firewall rule's reachability using its bound
+// interfaces and IP protocol.
+//
+// A rule counts as WAN-reachable when it applies to any WAN interface. This
+// includes:
+//   - Interface-scoped floating rules, which — like ordinary rules — are
+//     scoped to exactly the interfaces in rule.Interfaces; the Floating flag
+//     does not by itself widen a rule's reach beyond its interface list.
+//   - Unscoped floating rules (Floating == true with an empty rule.Interfaces),
+//     which apply to every interface and are therefore WAN-reachable whenever
+//     any WAN interface exists on the device.
+//   - IPv6-only WAN interfaces (rule.IPProtocol == IPProtocolInet6 bound to a
+//     WAN-named interface) — the WAN-name match alone is sufficient; the
+//     interface's IPv6Address is not required to be non-empty because a
+//     misconfigured/unassigned address must not mask a real exposure.
+func RuleReachability(rule common.FirewallRule, ifaces []common.Interface) Reachability {
+	// An unscoped floating rule (no interface list) applies device-wide, so it
+	// is WAN-reachable whenever any WAN interface exists. A floating rule WITH an
+	// explicit interface list is scoped to exactly those interfaces — the same
+	// as a non-floating rule — so it falls through to the name check below.
+	// Treating every floating rule as device-wide would false-positive a
+	// LAN-scoped floating rule (e.g. an anti-lockout rule) as WAN-reachable.
+	if rule.Floating && len(rule.Interfaces) == 0 {
+		if slices.ContainsFunc(ifaces, func(iface common.Interface) bool {
+			return IsWANInterfaceName(iface.Name)
+		}) {
+			return WANReachable
+		}
+
+		return LANOnly
+	}
+
+	if slices.ContainsFunc(rule.Interfaces, IsWANInterfaceName) {
+		return WANReachable
+	}
+
+	return LANOnly
+}
+
+// InboundNATRuleReachability reports whether an inbound (port-forward) NAT
+// rule is WAN-reachable.
+//
+// A NAT rule is WAN-reachable only when it is enabled, applies to a WAN
+// interface, AND at least one enabled pass rule also applies to a WAN
+// interface. NAT presence alone — with no matching enabled pass rule — is
+// never WAN-reachable: OPNsense and pfSense both require an explicit pass
+// rule (or an auto-added "filter rule association") to actually allow the
+// forwarded traffic through the firewall; a port-forward with no
+// corresponding pass rule is inert.
+func InboundNATRuleReachability(
+	nat common.InboundNATRule,
+	ifaces []common.Interface,
+	passRules []common.FirewallRule,
+) Reachability {
+	if nat.Disabled {
+		return Local
+	}
+
+	if !slices.ContainsFunc(nat.Interfaces, IsWANInterfaceName) {
+		return LANOnly
+	}
+
+	for _, rule := range passRules {
+		if rule.Disabled || rule.Type != common.RuleTypePass {
+			continue
+		}
+
+		if RuleReachability(rule, ifaces) == WANReachable {
+			return WANReachable
+		}
+	}
+
+	return LANOnly
+}

--- a/internal/analysis/reachability_test.go
+++ b/internal/analysis/reachability_test.go
@@ -1,0 +1,232 @@
+package analysis_test
+
+import (
+	"testing"
+
+	"github.com/EvilBit-Labs/opnDossier/internal/analysis"
+	common "github.com/EvilBit-Labs/opnDossier/pkg/model"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestIsWANInterfaceName_Characterization pins the current isWANInterface
+// behavior (case-insensitive "wan" prefix match) that previously lived,
+// duplicated, in internal/plugins/sans and internal/plugins/firewall. This
+// characterization test is the baseline the U1 consolidation must not
+// regress. Covers AE5.
+func TestIsWANInterfaceName_Characterization(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"wan", true},
+		{"WAN", true},
+		{"wan2", true},
+		{"WAN2", true},
+		{"wanbackup", true},
+		{"lan", false},
+		{"LAN", false},
+		{"opt1", false},
+		{"dmz", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, analysis.IsWANInterfaceName(tt.name))
+		})
+	}
+}
+
+// TestInterfaceReachability covers AE5 (multi-WAN, case-insensitivity) and
+// the loopback/local case named in U1's test scenarios.
+func TestInterfaceReachability(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		iface common.Interface
+		want  analysis.Reachability
+	}{
+		{
+			name:  "wan lowercase",
+			iface: common.Interface{Name: "wan", Enabled: true},
+			want:  analysis.WANReachable,
+		},
+		{
+			name:  "WAN uppercase",
+			iface: common.Interface{Name: "WAN", Enabled: true},
+			want:  analysis.WANReachable,
+		},
+		{
+			name:  "wan2 multi-wan",
+			iface: common.Interface{Name: "wan2", Enabled: true},
+			want:  analysis.WANReachable,
+		},
+		{
+			name:  "lan",
+			iface: common.Interface{Name: "lan", Enabled: true},
+			want:  analysis.LANOnly,
+		},
+		{
+			name:  "disabled wan is local",
+			iface: common.Interface{Name: "wan", Enabled: false},
+			want:  analysis.Local,
+		},
+		{
+			name:  "loopback is local",
+			iface: common.Interface{Name: "lo0", Enabled: true},
+			want:  analysis.Local,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, analysis.InterfaceReachability(tt.iface))
+		})
+	}
+}
+
+// TestRuleReachability covers AE6: floating rules, IPv6 WAN interfaces, and
+// regression parity with the pre-consolidation single-WAN behavior.
+func TestRuleReachability(t *testing.T) {
+	t.Parallel()
+
+	wanIface := common.Interface{Name: "wan", Enabled: true}
+	lanIface := common.Interface{Name: "lan", Enabled: true}
+	ifaces := []common.Interface{wanIface, lanIface}
+
+	tests := []struct {
+		name   string
+		rule   common.FirewallRule
+		ifaces []common.Interface
+		want   analysis.Reachability
+	}{
+		{
+			name:   "bound to wan interface",
+			rule:   common.FirewallRule{Interfaces: []string{"wan"}},
+			ifaces: ifaces,
+			want:   analysis.WANReachable,
+		},
+		{
+			name:   "bound to multi-wan wan2",
+			rule:   common.FirewallRule{Interfaces: []string{"wan2"}},
+			ifaces: []common.Interface{{Name: "wan2", Enabled: true}, lanIface},
+			want:   analysis.WANReachable,
+		},
+		{
+			name:   "bound to lan only",
+			rule:   common.FirewallRule{Interfaces: []string{"lan"}},
+			ifaces: ifaces,
+			want:   analysis.LANOnly,
+		},
+		{
+			name:   "floating rule with wan interface present",
+			rule:   common.FirewallRule{Floating: true},
+			ifaces: ifaces,
+			want:   analysis.WANReachable,
+		},
+		{
+			name:   "floating rule with no wan interface present",
+			rule:   common.FirewallRule{Floating: true},
+			ifaces: []common.Interface{lanIface},
+			want:   analysis.LANOnly,
+		},
+		{
+			name:   "interface-scoped floating rule to lan is not wan-reachable",
+			rule:   common.FirewallRule{Floating: true, Interfaces: []string{"lan"}},
+			ifaces: ifaces,
+			want:   analysis.LANOnly,
+		},
+		{
+			name:   "interface-scoped floating rule to wan is wan-reachable",
+			rule:   common.FirewallRule{Floating: true, Interfaces: []string{"wan"}},
+			ifaces: ifaces,
+			want:   analysis.WANReachable,
+		},
+		{
+			name: "ipv6 wan interface",
+			rule: common.FirewallRule{
+				Interfaces: []string{"wan"},
+				IPProtocol: common.IPProtocolInet6,
+			},
+			ifaces: []common.Interface{{Name: "wan", Enabled: true, IPv6Address: "2001:db8::1"}, lanIface},
+			want:   analysis.WANReachable,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, analysis.RuleReachability(tt.rule, tt.ifaces))
+		})
+	}
+}
+
+// TestInboundNATRuleReachability covers the AE6 NAT-without-pass-rule case:
+// NAT presence alone must never be reported WAN-reachable.
+func TestInboundNATRuleReachability(t *testing.T) {
+	t.Parallel()
+
+	ifaces := []common.Interface{{Name: "wan", Enabled: true}, {Name: "lan", Enabled: true}}
+
+	wanPassRule := common.FirewallRule{
+		Type:       common.RuleTypePass,
+		Interfaces: []string{"wan"},
+	}
+
+	tests := []struct {
+		name      string
+		nat       common.InboundNATRule
+		passRules []common.FirewallRule
+		want      analysis.Reachability
+	}{
+		{
+			name:      "NAT on WAN with no matching pass rule is not WAN-reachable",
+			nat:       common.InboundNATRule{Interfaces: []string{"wan"}},
+			passRules: nil,
+			want:      analysis.LANOnly,
+		},
+		{
+			name:      "NAT on WAN with a matching enabled WAN pass rule is WAN-reachable",
+			nat:       common.InboundNATRule{Interfaces: []string{"wan"}},
+			passRules: []common.FirewallRule{wanPassRule},
+			want:      analysis.WANReachable,
+		},
+		{
+			name: "NAT on WAN with only a disabled pass rule is not WAN-reachable",
+			nat:  common.InboundNATRule{Interfaces: []string{"wan"}},
+			passRules: []common.FirewallRule{
+				{Type: common.RuleTypePass, Interfaces: []string{"wan"}, Disabled: true},
+			},
+			want: analysis.LANOnly,
+		},
+		{
+			name:      "disabled NAT rule is local regardless of pass rules",
+			nat:       common.InboundNATRule{Interfaces: []string{"wan"}, Disabled: true},
+			passRules: []common.FirewallRule{wanPassRule},
+			want:      analysis.Local,
+		},
+		{
+			name:      "NAT rule not bound to WAN is LAN-only",
+			nat:       common.InboundNATRule{Interfaces: []string{"lan"}},
+			passRules: []common.FirewallRule{wanPassRule},
+			want:      analysis.LANOnly,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := analysis.InboundNATRuleReachability(tt.nat, ifaces, tt.passRules)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/analysis/statistics.go
+++ b/internal/analysis/statistics.go
@@ -201,13 +201,12 @@ func populateSystemStats(stats *common.Statistics, cfg *common.CommonDevice) {
 }
 
 func populateSecurityFeatures(stats *common.Statistics, cfg *common.CommonDevice) {
-	if wan := FindInterface(cfg.Interfaces, "wan"); wan != nil {
-		if wan.BlockPrivate {
-			stats.SecurityFeatures = append(stats.SecurityFeatures, "Block Private Networks")
-		}
-		if wan.BlockBogons {
-			stats.SecurityFeatures = append(stats.SecurityFeatures, "Block Bogon Networks")
-		}
+	blockPrivate, blockBogons := wanBlockingFlags(cfg.Interfaces)
+	if blockPrivate {
+		stats.SecurityFeatures = append(stats.SecurityFeatures, "Block Private Networks")
+	}
+	if blockBogons {
+		stats.SecurityFeatures = append(stats.SecurityFeatures, "Block Bogon Networks")
 	}
 	if cfg.System.WebGUI.Protocol == constants.ProtocolHTTPS {
 		stats.SecurityFeatures = append(stats.SecurityFeatures, "HTTPS Web GUI")
@@ -215,6 +214,36 @@ func populateSecurityFeatures(stats *common.Statistics, cfg *common.CommonDevice
 	if cfg.System.DisableNATReflection {
 		stats.SecurityFeatures = append(stats.SecurityFeatures, "NAT Reflection Disabled")
 	}
+}
+
+// wanBlockingFlags reports whether ANY WAN-reachable interface has
+// BlockPrivate/BlockBogons enabled, respectively. Using the canonical
+// reachability helper (rather than a single exact-name lookup) means
+// multi-WAN configurations (e.g. "wan2") are no longer silently dropped from
+// SecurityFeatures. Each flag is a single boolean across all WAN interfaces
+// so a device with multiple WAN interfaces does not emit duplicate feature
+// strings.
+//
+//nolint:gocritic // unnamedResult retained; project-wide nonamedreturns disables the typical fix.
+func wanBlockingFlags(ifaces []common.Interface) (bool, bool) {
+	blockPrivate := false
+	blockBogons := false
+
+	for _, iface := range ifaces {
+		if InterfaceReachability(iface) != WANReachable {
+			continue
+		}
+
+		if iface.BlockPrivate {
+			blockPrivate = true
+		}
+
+		if iface.BlockBogons {
+			blockBogons = true
+		}
+	}
+
+	return blockPrivate, blockBogons
 }
 
 // sortStatisticsLists enforces deterministic ordering on every slice-typed

--- a/internal/analysis/statistics_test.go
+++ b/internal/analysis/statistics_test.go
@@ -149,6 +149,27 @@ func TestComputeStatistics(t *testing.T) {
 			wantHasSecFeatures: true,
 			wantSecFeatures:    []string{"NAT Reflection Disabled"},
 		},
+		{
+			// Covers AE5 / U1 consolidation: the pre-consolidation exact-match
+			// `FindInterface(cfg.Interfaces, "wan")` site misses multi-WAN
+			// interfaces named "wan2", so BlockPrivate/BlockBogons on a
+			// secondary WAN interface were silently dropped from
+			// SecurityFeatures. Regression test pinning the fix.
+			name: "wan2 interface security features detected (multi-WAN)",
+			cfg: &common.CommonDevice{
+				Interfaces: []common.Interface{
+					{
+						Name:         "wan2",
+						Enabled:      true,
+						BlockPrivate: true,
+						BlockBogons:  true,
+					},
+				},
+			},
+			wantInterfaces:     1,
+			wantHasSecFeatures: true,
+			wantSecFeatures:    []string{"Block Private Networks", "Block Bogon Networks"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/audit/mode_controller.go
+++ b/internal/audit/mode_controller.go
@@ -192,7 +192,8 @@ func (mc *ModeController) generateBlueReport(_ context.Context, report *Report, 
 
 			// Warn if plugin produced findings with unrecognized severity values.
 			if counts := countSeverities(pluginFindings); counts.unknown > 0 {
-				mc.logger.Warn("Plugin produced findings with unrecognized severity",
+				mc.logger.Warn(
+					"Plugin produced findings with unrecognized severity",
 					"plugin", pluginName,
 					"unknownCount", counts.unknown,
 				)
@@ -213,8 +214,12 @@ func (mc *ModeController) generateBlueReport(_ context.Context, report *Report, 
 		report.Metadata["compliance_check_time"] = time.Now().Format(time.RFC3339)
 	}
 
-	// Add blue team specific analysis
-	report.addSecurityFindings()
+	// Run the shared detection engine once (KTD1-KTD3) and render its
+	// observations as blue hygiene findings, de-duplicated against the
+	// compliance findings just aggregated above.
+	observations := analysis.ScanObservations(report.Configuration)
+
+	report.addSecurityFindings(observations)
 	report.addComplianceAnalysis()
 	report.addRecommendations()
 	report.addStructuredConfigurationTables()
@@ -283,32 +288,202 @@ func (r *Report) TotalFindingsCount() int {
 	return total
 }
 
-// addSecurityFindings adds security findings to the blue team report.
-func (r *Report) addSecurityFindings() {
-	// Add placeholder security analysis
+// Rank constants for the R12 severity/reachability ordering below. Lower
+// values sort first (most urgent / most exposed leads).
+const (
+	rankCritical = iota
+	rankHigh
+	rankMedium
+	rankLow
+	rankInfo
+)
+
+const (
+	rankWANReachable = iota
+	rankLANOnly
+	rankLocal
+)
+
+// severityOrder ranks analysis.Severity from most to least urgent for R12
+// ordering (blue leads with the most severe findings).
+var severityOrder = map[analysis.Severity]int{
+	analysis.SeverityCritical: rankCritical,
+	analysis.SeverityHigh:     rankHigh,
+	analysis.SeverityMedium:   rankMedium,
+	analysis.SeverityLow:      rankLow,
+	analysis.SeverityInfo:     rankInfo,
+}
+
+// reachabilityOrder ranks analysis.Reachability from most to least exposed
+// for R12 ordering (blue leads with the most exposed findings within a
+// severity tier).
+var reachabilityOrder = map[analysis.Reachability]int{
+	analysis.WANReachable: rankWANReachable,
+	analysis.LANOnly:      rankLANOnly,
+	analysis.Local:        rankLocal,
+}
+
+// dedupeAgainstPluginFindings implements the R9/KTD4 de-dupe: a hygiene
+// observation is suppressed only when it references the same originating
+// config element (an exact Component string match) as a finding a fired
+// compliance plugin already emitted — never merely a shared category. This
+// deliberately uses `never merely a shared category` as the failure-safe
+// direction: with today's coarse-grained plugin Component values (e.g.
+// "firewall-rules"), few observations will match, but that under-matching
+// is the safe direction for a security tool — it never hides a finding that
+// should be shown.
+func (r *Report) dedupeAgainstPluginFindings(observations []analysis.Observation) []analysis.Observation {
+	fired := make(map[string]struct{})
+
+	for _, cr := range r.Compliance {
+		for _, f := range cr.Findings {
+			if f.Component != "" {
+				fired[f.Component] = struct{}{}
+			}
+		}
+	}
+
+	var deduped []analysis.Observation
+
+	for _, obs := range observations {
+		if _, matched := fired[obs.Component]; matched {
+			continue
+		}
+
+		deduped = append(deduped, obs)
+	}
+
+	return deduped
+}
+
+// addSecurityFindings renders the shared engine's observations as blue
+// hygiene findings appended to report.Findings (R7, R8), de-duplicated
+// against fired plugin controls (R9) and ordered by severity then
+// reachability (R12).
+func (r *Report) addSecurityFindings(observations []analysis.Observation) {
+	hygiene := r.dedupeAgainstPluginFindings(observations)
+
+	slices.SortStableFunc(hygiene, func(a, b analysis.Observation) int {
+		if sevDiff := severityOrder[a.Severity] - severityOrder[b.Severity]; sevDiff != 0 {
+			return sevDiff
+		}
+
+		return reachabilityOrder[a.Reachability] - reachabilityOrder[b.Reachability]
+	})
+
+	findings := make([]Finding, 0, len(hygiene))
+	for _, obs := range hygiene {
+		findings = append(findings, Finding{Finding: obs.ToFinding()})
+	}
+
+	r.Findings = append(r.Findings, findings...)
+
 	r.Metadata["security_scan_completed"] = true
 	r.Metadata["security_findings_count"] = r.TotalFindingsCount()
 }
 
-// addComplianceAnalysis adds compliance analysis to the blue team report.
+// addComplianceAnalysis derives the compliance-frameworks list from the
+// plugins actually executed (keys of report.Compliance, populated by
+// generateBlueReport), replacing the hardcoded three-framework list (R10).
 func (r *Report) addComplianceAnalysis() {
-	// Add placeholder compliance analysis
+	frameworks := make([]string, 0, len(r.Compliance))
+	for name := range r.Compliance {
+		frameworks = append(frameworks, strings.ToUpper(name))
+	}
+
+	slices.Sort(frameworks)
+
 	r.Metadata["compliance_check_completed"] = true
-	r.Metadata["compliance_frameworks"] = []string{"STIG", "NIST", "SANS"}
+	r.Metadata["compliance_frameworks"] = frameworks
 }
 
-// addRecommendations adds recommendations to the blue team report.
+// Recommendation groups the recommendation text synthesized for a single
+// configuration component across hygiene findings and compliance-plugin
+// findings (R11).
+type Recommendation struct {
+	// Component identifies the configuration component the recommendations apply to.
+	Component string `json:"component"`
+	// Recommendations lists the distinct recommendation strings for this component.
+	Recommendations []string `json:"recommendations"`
+}
+
+// addRecommendations synthesizes recommendations from the union of blue
+// hygiene findings (report.Findings) and compliance-plugin findings
+// (report.Compliance[*].Findings), grouped by Component, with a count
+// reflecting the real number of distinct recommendations (R11).
 func (r *Report) addRecommendations() {
-	// Add placeholder recommendations
+	grouped := make(map[string][]string)
+	order := make([]string, 0)
+
+	record := func(component, recommendation string) {
+		if recommendation == "" {
+			return
+		}
+
+		if _, exists := grouped[component]; !exists {
+			order = append(order, component)
+		}
+
+		if slices.Contains(grouped[component], recommendation) {
+			return
+		}
+
+		grouped[component] = append(grouped[component], recommendation)
+	}
+
+	for _, f := range r.Findings {
+		record(f.Component, f.Recommendation)
+	}
+
+	for _, cr := range r.Compliance {
+		for _, f := range cr.Findings {
+			record(f.Component, f.Recommendation)
+		}
+	}
+
+	slices.Sort(order)
+
+	recommendations := make([]Recommendation, 0, len(order))
+	count := 0
+
+	for _, component := range order {
+		recs := grouped[component]
+		recommendations = append(recommendations, Recommendation{Component: component, Recommendations: recs})
+		count += len(recs)
+	}
+
 	r.Metadata["recommendations_generated"] = true
-	r.Metadata["recommendation_count"] = 0
+	r.Metadata["recommendation_count"] = count
+	r.Metadata["recommendations"] = recommendations
 }
 
-// addStructuredConfigurationTables adds structured configuration tables to the blue team report.
+// ConfigSummaryTable is a single structured configuration-summary row built
+// from real configuration counts (R13).
+type ConfigSummaryTable struct {
+	// Category names the configuration element category being summarized.
+	Category string `json:"category"`
+	// Count is the number of configured elements in this category.
+	Count int `json:"count"`
+}
+
+// addStructuredConfigurationTables builds configuration summary tables from
+// actual configuration counts (interfaces, firewall rules, NAT rules,
+// users), replacing the hardcoded table count (R13).
 func (r *Report) addStructuredConfigurationTables() {
-	// Add placeholder structured tables
+	var tables []ConfigSummaryTable
+
+	if cfg := r.Configuration; cfg != nil {
+		tables = []ConfigSummaryTable{
+			{Category: "interfaces", Count: len(cfg.Interfaces)},
+			{Category: "firewallRules", Count: len(cfg.FirewallRules)},
+			{Category: "natRules", Count: len(cfg.NAT.InboundRules) + len(cfg.NAT.OutboundRules)},
+			{Category: "users", Count: len(cfg.Users)},
+		}
+	}
+
 	r.Metadata["structured_tables_generated"] = true
-	r.Metadata["table_count"] = 5
+	r.Metadata["table_count"] = len(tables)
+	r.Metadata["configuration_tables"] = tables
 }
 
 // stubMarker returns the canonical "not yet implemented" metadata value for

--- a/internal/audit/mode_controller_test.go
+++ b/internal/audit/mode_controller_test.go
@@ -3,6 +3,7 @@ package audit
 import (
 	"context"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/EvilBit-Labs/opnDossier/internal/analysis"
@@ -984,7 +985,11 @@ func TestReport_EmptySummary(t *testing.T) {
 	}
 }
 
-//nolint:tparallel // Subtests share mutable report state and cannot run concurrently
+// TestReport_AnalysisMethods exercises the blue-mode add* methods against a
+// config with a known-bad WebGUI protocol, asserting real derived values
+// (R23) rather than merely non-empty metadata.
+//
+//nolint:tparallel,funlen // subtests share mutable report state and cannot run concurrently; length is subtests asserting real values, not complexity
 func TestReport_AnalysisMethods(t *testing.T) {
 	t.Parallel()
 
@@ -995,43 +1000,134 @@ func TestReport_AnalysisMethods(t *testing.T) {
 			System: common.System{
 				Hostname: "test-host",
 				Domain:   "test.local",
+				WebGUI:   common.WebGUI{Protocol: "http"},
 			},
+			Interfaces: []common.Interface{
+				{Name: "wan", Enabled: true},
+				{Name: "lan", Enabled: true},
+			},
+			FirewallRules: []common.FirewallRule{
+				{Type: common.RuleTypePass, Interfaces: []string{"lan"}},
+			},
+			Users: []common.User{{Name: "admin"}},
 		},
 		Findings:   make([]Finding, 0),
 		Compliance: make(map[string]ComplianceResult),
 		Metadata:   make(map[string]any),
 	}
 
-	// Test the analysis methods that add metadata to the report
+	// Test the analysis methods that add metadata to the report. R23: assert
+	// real values derived from the config, not merely that metadata is
+	// non-empty.
 	t.Run("addSecurityFindings", func(t *testing.T) {
-		report.addSecurityFindings()
-		// Verify that security findings were added
-		if len(report.Metadata) == 0 {
-			t.Error("addSecurityFindings() should add security findings to the report")
+		observations := analysis.ScanObservations(report.Configuration)
+		report.addSecurityFindings(observations)
+
+		if len(report.Findings) == 0 {
+			t.Fatal("addSecurityFindings() should append hygiene findings for an insecure WebGUI config")
+		}
+
+		found := false
+		for _, f := range report.Findings {
+			if f.Title == "Insecure Web GUI Protocol" {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf(
+				"addSecurityFindings() findings = %+v, want a finding titled %q",
+				report.Findings,
+				"Insecure Web GUI Protocol",
+			)
+		}
+
+		if got := report.Metadata["security_findings_count"]; got != report.TotalFindingsCount() {
+			t.Errorf("security_findings_count = %v, want %d", got, report.TotalFindingsCount())
 		}
 	})
 
 	t.Run("addComplianceAnalysis", func(t *testing.T) {
 		report.addComplianceAnalysis()
-		// Verify that compliance analysis was added
-		if len(report.Metadata) == 0 {
-			t.Error("addComplianceAnalysis() should add compliance analysis to the report")
+
+		frameworks, ok := report.Metadata["compliance_frameworks"].([]string)
+		if !ok {
+			t.Fatalf(
+				"compliance_frameworks = %v (%T), want []string",
+				report.Metadata["compliance_frameworks"],
+				report.Metadata["compliance_frameworks"],
+			)
+		}
+		// No plugins were executed against this hand-built report, so the
+		// frameworks list must be empty — never the old hardcoded
+		// ["STIG","NIST","SANS"].
+		if len(frameworks) != 0 {
+			t.Errorf("compliance_frameworks = %v, want empty (no plugins executed)", frameworks)
 		}
 	})
 
 	t.Run("addRecommendations", func(t *testing.T) {
 		report.addRecommendations()
-		// Verify that recommendations were added
-		if len(report.Metadata) == 0 {
-			t.Error("addRecommendations() should add recommendations to the report")
+
+		count, ok := report.Metadata["recommendation_count"].(int)
+		if !ok {
+			t.Fatalf(
+				"recommendation_count = %v (%T), want int",
+				report.Metadata["recommendation_count"],
+				report.Metadata["recommendation_count"],
+			)
+		}
+		if count == 0 {
+			t.Error("recommendation_count = 0, want > 0 given the hygiene findings from the insecure config")
+		}
+
+		recs, ok := report.Metadata["recommendations"].([]Recommendation)
+		if !ok {
+			t.Fatalf(
+				"recommendations = %v (%T), want []Recommendation",
+				report.Metadata["recommendations"],
+				report.Metadata["recommendations"],
+			)
+		}
+		if len(recs) == 0 {
+			t.Error("recommendations should be non-empty")
 		}
 	})
 
 	t.Run("addStructuredConfigurationTables", func(t *testing.T) {
 		report.addStructuredConfigurationTables()
-		// Verify that structured configuration tables were added
-		if len(report.Metadata) == 0 {
-			t.Error("addStructuredConfigurationTables() should add structured configuration tables to the report")
+
+		tableCount, ok := report.Metadata["table_count"].(int)
+		if !ok {
+			t.Fatalf("table_count = %v (%T), want int", report.Metadata["table_count"], report.Metadata["table_count"])
+		}
+
+		tables, ok := report.Metadata["configuration_tables"].([]ConfigSummaryTable)
+		if !ok {
+			t.Fatalf(
+				"configuration_tables = %v (%T), want []ConfigSummaryTable",
+				report.Metadata["configuration_tables"],
+				report.Metadata["configuration_tables"],
+			)
+		}
+		if tableCount != len(tables) {
+			t.Errorf("table_count = %d, want len(configuration_tables) = %d", tableCount, len(tables))
+		}
+
+		wantCounts := map[string]int{
+			"interfaces":    2,
+			"firewallRules": 1,
+			"natRules":      0,
+			"users":         1,
+		}
+		for _, tbl := range tables {
+			want, known := wantCounts[tbl.Category]
+			if !known {
+				t.Errorf("unexpected table category %q", tbl.Category)
+				continue
+			}
+			if tbl.Count != want {
+				t.Errorf("table %q count = %d, want %d", tbl.Category, tbl.Count, want)
+			}
 		}
 	})
 
@@ -1085,6 +1181,145 @@ func assertStubMarker(t *testing.T, report *Report, key string) {
 	stub, ok := marker["stub"].(bool)
 	if !ok || !stub {
 		t.Errorf("metadata[%q].stub: expected true, got %v", key, marker["stub"])
+	}
+}
+
+// TestAddSecurityFindings_DedupeAgainstFiredPluginControls covers AE1
+// (R8, R9): a hygiene observation referencing the same config element (an
+// exact Component match) as a fired plugin finding is suppressed, while a
+// hygiene observation on a different element in the same category is still
+// emitted.
+func TestAddSecurityFindings_DedupeAgainstFiredPluginControls(t *testing.T) {
+	t.Parallel()
+
+	report := &Report{
+		Mode:          ModeBlue,
+		Configuration: &common.CommonDevice{},
+		Findings:      make([]Finding, 0),
+		Compliance: map[string]ComplianceResult{
+			"firewall": {
+				Findings: []compliance.Finding{
+					{
+						Type:      "compliance",
+						Severity:  "high",
+						Title:     "Any Source on WAN Inbound",
+						Component: "filter.rule[0]",
+					},
+				},
+			},
+		},
+		Metadata: make(map[string]any),
+	}
+
+	observations := []analysis.Observation{
+		{
+			Severity:       analysis.SeverityHigh,
+			Confidence:     analysis.ConfidenceHigh,
+			Reachability:   analysis.WANReachable,
+			Component:      "filter.rule[0]",
+			Title:          "Overly Permissive WAN Rule",
+			Description:    "Rule 1 allows any source to pass traffic on WAN interface",
+			Recommendation: "Restrict source networks",
+		},
+		{
+			Severity:       analysis.SeverityHigh,
+			Confidence:     analysis.ConfidenceHigh,
+			Reachability:   analysis.WANReachable,
+			Component:      "filter.rule[1]",
+			Title:          "Overly Permissive WAN Rule",
+			Description:    "Rule 2 allows any source to pass traffic on WAN interface",
+			Recommendation: "Restrict source networks",
+		},
+	}
+
+	report.addSecurityFindings(observations)
+
+	if len(report.Findings) != 1 {
+		t.Fatalf(
+			"addSecurityFindings() len(Findings) = %d, want 1 (rule[0] suppressed as a duplicate of the fired plugin control, rule[1] retained)",
+			len(report.Findings),
+		)
+	}
+
+	if report.Findings[0].Component != "filter.rule[1]" {
+		t.Errorf(
+			"addSecurityFindings() surviving finding Component = %q, want %q",
+			report.Findings[0].Component, "filter.rule[1]",
+		)
+	}
+}
+
+// TestAddSecurityFindings_OrderedBySeverityThenReachability covers R12:
+// hygiene findings are ordered by severity (most urgent first), then by
+// reachability (most exposed first) within a severity tier.
+func TestAddSecurityFindings_OrderedBySeverityThenReachability(t *testing.T) {
+	t.Parallel()
+
+	report := &Report{
+		Mode:          ModeBlue,
+		Configuration: &common.CommonDevice{},
+		Findings:      make([]Finding, 0),
+		Compliance:    make(map[string]ComplianceResult),
+		Metadata:      make(map[string]any),
+	}
+
+	observations := []analysis.Observation{
+		{Severity: analysis.SeverityMedium, Reachability: analysis.WANReachable, Component: "a", Title: "medium-wan"},
+		{Severity: analysis.SeverityCritical, Reachability: analysis.Local, Component: "b", Title: "critical-local"},
+		{Severity: analysis.SeverityHigh, Reachability: analysis.LANOnly, Component: "c", Title: "high-lan"},
+		{Severity: analysis.SeverityHigh, Reachability: analysis.WANReachable, Component: "d", Title: "high-wan"},
+	}
+
+	report.addSecurityFindings(observations)
+
+	wantOrder := []string{"critical-local", "high-wan", "high-lan", "medium-wan"}
+	gotOrder := make([]string, len(report.Findings))
+	for i, f := range report.Findings {
+		gotOrder[i] = f.Title
+	}
+
+	if !slices.Equal(gotOrder, wantOrder) {
+		t.Errorf("addSecurityFindings() order = %v, want %v", gotOrder, wantOrder)
+	}
+}
+
+// TestAddComplianceAnalysis_FrameworksDerivedFromExecutedPlugins covers AE4
+// (R10): `--plugins stig` produces a compliance_frameworks list of exactly
+// ["STIG"], not the previously hardcoded ["STIG","NIST","SANS"].
+func TestAddComplianceAnalysis_FrameworksDerivedFromExecutedPlugins(t *testing.T) {
+	t.Parallel()
+
+	registry := NewPluginRegistry()
+	if err := registry.RegisterPlugin(stig.NewPlugin()); err != nil {
+		t.Fatalf("RegisterPlugin(stig): %v", err)
+	}
+
+	logger := newTestLogger(t)
+	controller := NewModeController(registry, logger)
+
+	device := &common.CommonDevice{
+		System: common.System{Hostname: "fw", Domain: "example.com"},
+	}
+
+	report, err := controller.GenerateReport(context.Background(), device, &ModeConfig{
+		Mode:            ModeBlue,
+		SelectedPlugins: []string{"stig"},
+	})
+	if err != nil {
+		t.Fatalf("GenerateReport() unexpected error: %v", err)
+	}
+
+	frameworks, ok := report.Metadata["compliance_frameworks"].([]string)
+	if !ok {
+		t.Fatalf(
+			"compliance_frameworks = %v (%T), want []string",
+			report.Metadata["compliance_frameworks"], report.Metadata["compliance_frameworks"],
+		)
+	}
+
+	want := []string{"STIG"}
+	if !slices.Equal(frameworks, want) {
+		t.Errorf("compliance_frameworks = %v, want %v", frameworks, want)
 	}
 }
 

--- a/internal/plugins/firewall/checks_rules.go
+++ b/internal/plugins/firewall/checks_rules.go
@@ -4,6 +4,7 @@ package firewall
 import (
 	"strings"
 
+	"github.com/EvilBit-Labs/opnDossier/internal/analysis"
 	"github.com/EvilBit-Labs/opnDossier/internal/constants"
 	common "github.com/EvilBit-Labs/opnDossier/pkg/model"
 )
@@ -14,15 +15,6 @@ import (
 //
 
 const disabledRuleThreshold = 10
-
-// isWANInterface reports whether the given interface name represents a WAN
-// interface. The check is case-insensitive and matches "wan" as well as
-// prefixed variants like "wan2".
-func isWANInterface(name string) bool {
-	lower := strings.ToLower(name)
-
-	return lower == "wan" || strings.HasPrefix(lower, "wan")
-}
 
 // checkNoAnyAnyPassRules checks that no firewall pass rules exist with source,
 // destination, port, and protocol all set to "any". Such rules effectively
@@ -68,7 +60,7 @@ func (fp *Plugin) checkNoAnySourceOnWANInbound(device *common.CommonDevice) chec
 		}
 
 		for _, iface := range rule.Interfaces {
-			if isWANInterface(iface) && rule.Source.Address == constants.NetworkAny {
+			if analysis.IsWANInterfaceName(iface) && rule.Source.Address == constants.NetworkAny {
 				return checkResult{Result: false, Known: true}
 			}
 		}
@@ -194,7 +186,7 @@ func (fp *Plugin) checkPrivateAddressFilteringOnWAN(device *common.CommonDevice)
 
 	foundWAN := false
 	for _, iface := range device.Interfaces {
-		if isWANInterface(iface.Name) {
+		if analysis.IsWANInterfaceName(iface.Name) {
 			foundWAN = true
 			if !iface.BlockPrivate {
 				return checkResult{Result: false, Known: true}
@@ -218,7 +210,7 @@ func (fp *Plugin) checkBogonFilteringOnWAN(device *common.CommonDevice) checkRes
 
 	foundWAN := false
 	for _, iface := range device.Interfaces {
-		if isWANInterface(iface.Name) {
+		if analysis.IsWANInterfaceName(iface.Name) {
 			foundWAN = true
 			if !iface.BlockBogons {
 				return checkResult{Result: false, Known: true}

--- a/internal/plugins/sans/checks.go
+++ b/internal/plugins/sans/checks.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/EvilBit-Labs/opnDossier/internal/analysis"
 	"github.com/EvilBit-Labs/opnDossier/internal/constants"
 	common "github.com/EvilBit-Labs/opnDossier/pkg/model"
 )
@@ -38,12 +39,6 @@ var appLayerProxyPackages = []string{
 	"squid",
 }
 
-// isWANInterface reports whether the interface name represents a WAN interface.
-func isWANInterface(name string) bool {
-	lower := strings.ToLower(name)
-	return lower == "wan" || strings.HasPrefix(lower, "wan")
-}
-
 // isDMZOrOPTInterface reports whether the interface name represents a DMZ or OPT interface.
 func isDMZOrOPTInterface(name string) bool {
 	lower := strings.ToLower(name)
@@ -64,7 +59,7 @@ func enabledPassRules(device *common.CommonDevice) []common.FirewallRule {
 
 // ruleAppliesToWAN reports whether a firewall rule applies to any WAN interface.
 func ruleAppliesToWAN(rule common.FirewallRule) bool {
-	return slices.ContainsFunc(rule.Interfaces, isWANInterface)
+	return slices.ContainsFunc(rule.Interfaces, analysis.IsWANInterfaceName)
 }
 
 // portMatchesDangerous checks whether a port specification matches any dangerous port.
@@ -330,7 +325,7 @@ func (sp *Plugin) checkAntiSpoofing(device *common.CommonDevice) checkResult {
 
 	hasWAN := false
 	for _, iface := range device.Interfaces {
-		if !iface.Enabled || !isWANInterface(iface.Name) {
+		if !iface.Enabled || !analysis.IsWANInterfaceName(iface.Name) {
 			continue
 		}
 		hasWAN = true


### PR DESCRIPTION
## Summary

Replaces the placeholder blue-mode analysis in the `audit` command with real `CommonDevice` analysis, built on a shared detection engine that a later PR will also use for red mode. This is the first of two slices; **red mode remains stubbed and ships separately**.

### Shared engine
- One canonical WAN-reachability helper (WAN-reachable / LAN-only / local), replacing two duplicate `isWANInterface` plugin helpers and two narrower exact-match WAN checks in `internal/analysis`. The exact-match sites silently missed multi-WAN interfaces (e.g. `wan2`); the consolidated helper handles them, plus interface-scoped floating rules, IPv6 WAN interfaces, and inbound NAT rules gated on a matching enabled pass rule.
- A neutral `Observation` type (severity, confidence label, evidence, reachability) and a `ScanObservations` engine that wraps the existing detectors **without changing their signatures** — the JSON/YAML export path is unaffected — and adds framework-free hygiene detectors (insecure SNMP, weak TLS floor, any-to-any rules, disabled logging).

### Blue mode
- Real hygiene findings appended to `report.Findings`, de-duplicated against fired compliance-plugin findings by config-element identity and ordered by severity then reachability.
- Compliance-frameworks list derived from the plugins actually executed (was a hardcoded `["STIG","NIST","SANS"]`).
- Recommendations synthesized from hygiene + plugin findings; configuration summary tables built from real counts (were hardcoded).

## Known limitations / follow-ups
- WAN detection is name-prefix-only; a secondary internet uplink left with its default name (e.g. `opt1`) is under-reported. Documented inline; gateway-based detection is a tracked follow-up.
- Blue de-dupe joins on config-element identity, which under-matches today's coarse-grained plugin `Component` values (safe direction — it never hides a finding). Documented inline.
- Red mode (adversarial lens) is intentionally still stubbed — slice 2.

## Test plan
- [x] `golangci-lint run` — 0 issues; `modernize` clean; `gofumpt` clean; `mdformat` clean
- [x] `go test ./internal/analysis/... ./internal/audit/... ./internal/plugins/... ./internal/converter/... ./internal/processor/...` — pass
- [x] New regression coverage: multi-WAN (`wan2`), interface-scoped floating rules (LAN-scoped floating no longer false-positives as WAN), IPv6 WAN, disabled-rule exclusion, blue de-dupe / frameworks-from-executed-plugins / severity+reachability ordering
- [ ] `just test-race`'s `TestPerformanceBaselines` (in `internal/converter`, untouched by this PR) uses hardcoded microsecond baselines that are load-fragile under `-race` and can flake locally; the race detector is not run in CI, so this does not gate the PR

## CI note
All required checks pass (Mergify Merge Protections green; Lint, Build, Coverage, Integration Tests, Performance Benchmarks, Startup Time, CodeQL, and Test on macOS/Ubuntu/Windows all green). The single failing check — **License Compliance (FOSSA)** — is non-blocking and unrelated to this PR: the branch changes **zero dependencies** (`go.mod`/`go.sum` untouched), so the flagged license-policy issue is pre-existing repo/FOSSA state, not introduced here. No slice-1 code fix applies; flagging for maintainer awareness.

## AI usage
Used Claude Code (Claude Opus 4.8) for implementation and review of this slice. All code reviewed, linted, and tested before merge. See [AI_POLICY.md](AI_POLICY.md).

Part of the audit blue/red mode epic (#281).
