### PR TITLE
fix(sanitizer): redact NetBird setupKey enrollment token

### DIFF
--- a/GOTCHAS.md
+++ b/GOTCHAS.md
@@ -282,6 +282,15 @@ OpenVPN's `<tls>` element (under `<openvpn-server>` / `<openvpn-client>`) holds 
 
 - **History:** SEC-H1 from the 2026-04-19 comprehensive review. Prior to the fix, `opnDossier sanitize` silently leaked raw HMAC keys sufficient to forge OpenVPN handshakes — the headline promise of the subcommand.
 
+### 11.4 NetBird `setupKey` Is a Credential
+
+The OPNsense `os-netbird` plugin persists the NetBird enrollment/setup key as `<setupKey>` under `<OPNsense><netbird><authentication>` (MVC model mounted at `//OPNsense/netbird/authentication`). The value is a UUID-format registration token. Because the sanitizer's bare `"key"` FieldPattern is exact-match only (see `exactMatchPatterns` — same trap as SNMPv3 `<enckey>`), compound names like `setupKey` leaked through `sanitize` in cleartext.
+
+- **Symptom:** `sanitize` leaves NetBird setup keys readable in output. The key remains in `config.xml` when NetBird is disabled and often survives plugin removal as orphaned MVC XML, so disabled/removed plugins still leak.
+- **Fix:** Add `"setupkey"`, `"setup_key"`, `"setup-key"` to the `secret` rule's `FieldPatterns` in `internal/sanitizer/rules.go` and to `passwordKeywords` in `internal/sanitizer/patterns.go`.
+- **Detection:** `TestSanitizeXML_NetBirdSetupKey` in `internal/sanitizer/sanitizer_test.go`; `TestRedact_NetBirdSetupKey` in `rules_fieldpattern_test.go`.
+- **Upstream:** https://github.com/opnsense/plugins (`security/netbird`); field declared in `Authentication.xml` as `UpdateOnlyTextField` with UUID mask.
+
 ## 12. Git Tagging
 
 ### 12.1 Tag the Squash-Merge Commit on Main

--- a/internal/sanitizer/patterns.go
+++ b/internal/sanitizer/patterns.go
@@ -289,6 +289,10 @@ var (
 		// <openvpn-server>/<openvpn-client>; `<StaticKeys>` holds MVC
 		// static-key material. See GOTCHAS §11.3.
 		"statickeys", "tls_crypt", "tls_auth",
+		// NetBird: `<setupKey>` under OPNsense/netbird/authentication.
+		// Bare "key" is exact-match only for FieldPatterns; keep the
+		// keyword list in sync so LooksLikePassword stays consistent.
+		"setupkey", "setup_key", "setup-key",
 	}
 	apiKeywords = []string{"apikey", "api_key", "api-key", "accesskey", "secretkey"}
 	pskKeywords = []string{"psk", "preshared", "pre-shared", "ipsecpsk"}

--- a/internal/sanitizer/patterns_test.go
+++ b/internal/sanitizer/patterns_test.go
@@ -478,6 +478,8 @@ func TestLooksLikePassword(t *testing.T) {
 		{"secretKey", true},
 		{"apiToken", true},
 		{"authKey", true},
+		{"setupKey", true},
+		{"setup_key", true},
 		{"ldap_bindpw", true},
 		{"privateKey", true},
 		{"username", false},

--- a/internal/sanitizer/patterns_test.go
+++ b/internal/sanitizer/patterns_test.go
@@ -480,6 +480,7 @@ func TestLooksLikePassword(t *testing.T) {
 		{"authKey", true},
 		{"setupKey", true},
 		{"setup_key", true},
+		{"setup-key", true},
 		{"ldap_bindpw", true},
 		{"privateKey", true},
 		{"username", false},

--- a/internal/sanitizer/rules.go
+++ b/internal/sanitizer/rules.go
@@ -282,6 +282,13 @@ func builtinRules() []Rule {
 				"secret", "token", "apikey", "api_key", "api-key",
 				"accesskey", "secretkey", "authkey", "auth_key",
 				"otp_seed", "otpseed",
+				// NetBird enrollment/setup key from the OPNsense os-netbird
+				// plugin (<OPNsense><netbird><authentication><setupKey>).
+				// The bare "key" pattern on private_key is exact-match only
+				// (see exactMatchPatterns), so "setupKey" needs its own
+				// substring alias. The value persists in config.xml when the
+				// service is disabled and often survives plugin removal.
+				"setupkey", "setup_key", "setup-key",
 			},
 			Redactor: func(_ *Mapper, _, _ string) string {
 				return redactedSecretValue

--- a/internal/sanitizer/rules_fieldpattern_test.go
+++ b/internal/sanitizer/rules_fieldpattern_test.go
@@ -114,6 +114,38 @@ func TestRedact_OTPSeed(t *testing.T) {
 	}
 }
 
+func TestRedact_NetBirdSetupKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		mode  Mode
+		field string
+	}{
+		{ModeAggressive, "setupKey"},
+		{ModeModerate, "setupKey"},
+		{ModeMinimal, "setupKey"},
+		{ModeAggressive, "setup_key"},
+		{ModeModerate, "setup_key"},
+		{ModeMinimal, "setup_key"},
+		{ModeAggressive, "setup-key"},
+		{ModeModerate, "setup-key"},
+		{ModeMinimal, "setup-key"},
+		{ModeAggressive, "OPNsense.netbird.authentication.setupKey"},
+		{ModeMinimal, "netbird.authentication.setupKey"},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.mode)+"_"+tt.field, func(t *testing.T) {
+			t.Parallel()
+			engine := NewRuleEngine(tt.mode)
+			result := engine.Redact(tt.field, "A1B2C3D4-E5F6-7890-ABCD-EF1234567890")
+			if result != redactedSecretValue {
+				t.Errorf("Redact(%q, setup key) = %q, want %q", tt.field, result, redactedSecretValue)
+			}
+		})
+	}
+}
+
 func TestRedact_KeyField(t *testing.T) {
 	t.Parallel()
 

--- a/internal/sanitizer/rules_test.go
+++ b/internal/sanitizer/rules_test.go
@@ -130,7 +130,7 @@ func TestShouldRedactField_AuthServer(t *testing.T) {
 func TestShouldRedactField_Secret(t *testing.T) {
 	engine := NewRuleEngine(ModeMinimal)
 
-	secretFields := []string{"secret", "token", "apikey", "api_key", "authkey"}
+	secretFields := []string{"secret", "token", "apikey", "api_key", "authkey", "setupkey", "setup_key", "setup-key"}
 	for _, field := range secretFields {
 		should, rule := engine.ShouldRedactField(field)
 		if !should {

--- a/internal/sanitizer/sanitizer_test.go
+++ b/internal/sanitizer/sanitizer_test.go
@@ -334,6 +334,76 @@ func TestSanitizeXML_SNMPv3EncKey(t *testing.T) {
 	}
 }
 
+// TestSanitizeXML_NetBirdSetupKey verifies the OPNsense os-netbird plugin's
+// enrollment key (<setupKey>) is redacted. The bare "key" FieldPattern is
+// exact-match only (see exactMatchPatterns), so camelCase/compound forms of
+// setupKey leaked in cleartext — including when NetBird is disabled or the
+// plugin has been removed but its <OPNsense><netbird> XML remains in config.
+func TestSanitizeXML_NetBirdSetupKey(t *testing.T) {
+	const setupKeyBody = "A1B2C3D4-E5F6-7890-ABCD-EF1234567890"
+
+	fixtures := []struct {
+		name string
+		xml  string
+	}{
+		{
+			name: "netbird_setupKey",
+			xml: "<opnsense><OPNsense><netbird><authentication><setupKey>" +
+				setupKeyBody +
+				"</setupKey><managementUrl>https://api.netbird.io</managementUrl>" +
+				"</authentication></netbird></OPNsense></opnsense>",
+		},
+		{
+			name: "setup_key_alias",
+			xml: "<opnsense><OPNsense><netbird><authentication><setup_key>" +
+				setupKeyBody +
+				"</setup_key></authentication></netbird></OPNsense></opnsense>",
+		},
+		{
+			name: "setup-key_alias",
+			xml: "<opnsense><OPNsense><netbird><authentication><setup-key>" +
+				setupKeyBody +
+				"</setup-key></authentication></netbird></OPNsense></opnsense>",
+		},
+		{
+			// Orphaned plugin config (service disabled / package removed) still
+			// carries the enrollment key under the OPNsense MVC namespace.
+			name: "orphaned_disabled_netbird",
+			xml: "<opnsense><OPNsense><netbird><settings><general><enabled>0</enabled>" +
+				"</general></settings><authentication><setupKey>" +
+				setupKeyBody +
+				"</setupKey></authentication></netbird></OPNsense></opnsense>",
+		},
+	}
+
+	for _, mode := range ValidModes() {
+		for _, fx := range fixtures {
+			t.Run(string(mode)+"_"+fx.name, func(t *testing.T) {
+				s := NewSanitizer(mode)
+				var output bytes.Buffer
+				if err := s.SanitizeXML(strings.NewReader(fx.xml), &output); err != nil {
+					t.Fatalf("SanitizeXML() error = %v", err)
+				}
+				result := output.String()
+				if strings.Contains(result, setupKeyBody) {
+					t.Errorf("mode=%q fixture=%q leaked NetBird setupKey: %s", mode, fx.name, result)
+				}
+				if !strings.Contains(result, redactedSecretValue) {
+					t.Errorf("mode=%q fixture=%q missing redaction marker: %s", mode, fx.name, result)
+				}
+				// Management URL is not a credential. Aggressive mode may still
+				// rewrite hostnames via the value detector; only assert survival
+				// in modes that leave hostnames intact.
+				if mode != ModeAggressive &&
+					strings.Contains(fx.xml, "api.netbird.io") &&
+					!strings.Contains(result, "https://api.netbird.io") {
+					t.Errorf("mode=%q fixture=%q unexpectedly redacted managementUrl: %s", mode, fx.name, result)
+				}
+			})
+		}
+	}
+}
+
 // TestSanitizeXML_SNMPv3Password verifies the net-snmp plugin's SNMPv3 auth
 // passphrase (<password>) is redacted via the generic password rule — guards
 // against an accidental rule reshuffle when the enckey alias was added.


### PR DESCRIPTION
## Summary
- `opnDossier sanitize` left the OPNsense os-netbird `<setupKey>` enrollment token in cleartext because bare "key"` FieldPatterns are exact-match only (same trap as SNMPv3 `<enckey>`).
- The key persists in `config.xml` when NetBird is disabled and often survives plugin removal as orphaned `<OPNsense><netbird>` XML, so disabled/removed installs still leaked.
- Adds `setupkey` / `setup_key` / `setup-key` aliases to the `secret` rule and `passwordKeywords`, with XML + unit tests and a GOTCHAS §11.4 note.

## Test plan
- [x] `go test ./internal/sanitizer/ -count=1`
- [ ] Run `opnDossier sanitize` on a config containing `<OPNsense><netbird><authentication><setupKey>…</setupKey>` and confirm the UUID is replaced with `[REDACTED-SECRET]`
- [ ] Confirm key is still redacted when `<enabled>0</enabled>` (or after plugin removal with leftover MVC XML)
- [ ] Confirm management URL is not treated as a credential in moderate/minimal modes
