### PR TITLE
docs(user-guide): sweep version examples to v1.7.0

### DIFF
--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -32,7 +32,7 @@ go install github.com/EvilBit-Labs/opnDossier@latest
 opndossier version
 ```
 
-**Expected result:** a version string such as `opnDossier v1.6.0`.
+**Expected result:** a version string such as `opnDossier v1.7.0`.
 
 If you see `command not found`, ensure the Go bin directory (typically `$HOME/go/bin`) is in your `PATH`.
 

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -158,7 +158,7 @@ If you have [Cosign](https://docs.sigstore.dev/cosign/system_config/installation
 # Download the signature bundle
 curl -LO https://github.com/EvilBit-Labs/opnDossier/releases/latest/download/opnDossier_checksums.txt.sigstore.json
 
-# Verify (replace TAG with the release tag, e.g. v1.6.0)
+# Verify (replace TAG with the release tag, e.g. v1.7.0)
 cosign verify-blob \
   --certificate-identity "https://github.com/EvilBit-Labs/opnDossier/.github/workflows/release.yml@refs/tags/TAG" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \


### PR DESCRIPTION
## Summary

The v1.7.0 release swept `action.yml` and the README GitHub Action examples, but left the user-guide version examples at `v1.6.0`. This updates the two remaining callsites.

- **`docs/user-guide/getting-started.md`** — the documented expected output of `opndossier version`. This one contradicted observed behavior: the current release prints `v1.7.0`, so a user following the guide saw a mismatch on their first verification step.
- **`docs/user-guide/installation.md`** — the cosign verification `TAG` placeholder example. Stale but self-labeled ("replace TAG"), so cosmetic.

`RELEASING.md` names both files explicitly in its release checklist:

> Sweep user-guide docs for stale version examples — `grep -rn "vPREV.Y.Z" docs/user-guide/` … covers `getting-started.md` version-output example, `installation.md` cosign TAG example

That step was missed this cycle. After this change, `grep -rn 'v1\.6\.0' docs/user-guide/` returns nothing.

## Scope

Docs only — two lines, no code, no behavior change. Remaining `v1.6.0` references elsewhere in the repo are intentional and untouched: `CHANGELOG.md` / `RELEASE_NOTES.md` (historical references to the prior release) and `go.mod` / `go.sum` / `THIRD_PARTY_NOTICES` (unrelated dependency versions).

## Test plan

- [x] `just ci-check` passes (lint, tests, race detector)
- [x] `pre-commit run -a` passes, including `mdformat`
- [x] `grep -rn 'v1\.6\.0' docs/user-guide/` returns no matches
- [x] Verified against the installed binary: `opndossier version` reports `1.7.0`, matching the updated `getting-started.md` example

## AI usage

Drafted with Claude Code (Opus 5). All changes reviewed and verified locally. See [AI_POLICY.md](AI_POLICY.md).
