### PR TITLE
fix(schema): unmarshal OPNsense <bridged> elements

### DIFF
--- a/pkg/parser/opnsense/converter_network.go
+++ b/pkg/parser/opnsense/converter_network.go
@@ -7,16 +7,41 @@ import (
 	schema "github.com/EvilBit-Labs/opnDossier/pkg/schema/opnsense"
 )
 
+// isBridgePlaceholder reports whether a <bridged> element carries no data at all.
+//
+// OPNsense emits a self-closing <bridged/> marker inside <bridges> when no bridge
+// is configured (the shipped testdata/opnsense-config.dtd declares it as
+// "<!ELEMENT bridged EMPTY>" for exactly this reason). Such an element is a
+// structural placeholder, not a bridge.
+//
+// The check is deliberately conservative: an entry is dropped only when every
+// field is zero. A bridge carrying any data at all -- even just a description --
+// is retained, because under-reporting configured resources is the more dangerous
+// direction for an auditing tool.
+func isBridgePlaceholder(b schema.Bridge) bool {
+	return b.Bridgeif == "" &&
+		b.Members == "" &&
+		b.Descr == "" &&
+		!bool(b.STP) &&
+		b.Created == "" &&
+		b.Updated == ""
+}
+
 // convertBridges maps doc.Bridges.Bridge to []common.Bridge.
 // Bridge members are stored as a comma-separated string in OPNsense XML and
 // split into individual interface names for the platform-agnostic model.
+//
+// Empty <bridged/> placeholders are skipped so they neither surface as blank
+// bridges in exported output nor inflate Statistics.TotalBridges. The result is
+// grown on demand rather than preallocated because the loop may skip entries.
 func (c *converter) convertBridges(doc *schema.OpnSenseDocument) []common.Bridge {
-	if len(doc.Bridges.Bridge) == 0 {
-		return nil
-	}
+	var result []common.Bridge
 
-	result := make([]common.Bridge, 0, len(doc.Bridges.Bridge))
 	for _, b := range doc.Bridges.Bridge {
+		if isBridgePlaceholder(b) {
+			continue
+		}
+
 		result = append(result, common.Bridge{
 			BridgeIf:    b.Bridgeif,
 			Members:     splitNonEmpty(b.Members, ","),

--- a/pkg/parser/opnsense/converter_network_test.go
+++ b/pkg/parser/opnsense/converter_network_test.go
@@ -1,9 +1,14 @@
 package opnsense_test
 
 import (
+	"context"
+	"strings"
 	"testing"
 
+	"github.com/EvilBit-Labs/opnDossier/internal/analysis"
+	"github.com/EvilBit-Labs/opnDossier/internal/cfgparser"
 	common "github.com/EvilBit-Labs/opnDossier/pkg/model"
+	"github.com/EvilBit-Labs/opnDossier/pkg/parser"
 	"github.com/EvilBit-Labs/opnDossier/pkg/parser/opnsense"
 	schema "github.com/EvilBit-Labs/opnDossier/pkg/schema/opnsense"
 	"github.com/stretchr/testify/assert"
@@ -44,6 +49,24 @@ func TestConverter_Bridges(t *testing.T) {
 				{Bridgeif: "bridge1", Members: "opt3", Descr: "DMZ"},
 			},
 			wantLen: 2,
+		},
+		{
+			name:    "empty bridged placeholder is skipped",
+			bridges: []schema.Bridge{{}},
+			wantLen: 0,
+		},
+		{
+			name: "placeholder alongside a real bridge keeps only the real one",
+			bridges: []schema.Bridge{
+				{},
+				{Bridgeif: "bridge0", Members: "opt1,opt2", Descr: "Internal"},
+			},
+			wantLen: 1,
+		},
+		{
+			name:    "bridge carrying only a description is retained",
+			bridges: []schema.Bridge{{Descr: "staged bridge"}},
+			wantLen: 1,
 		},
 	}
 
@@ -572,4 +595,70 @@ func TestConverter_InterfaceGroups_SpaceSeparated(t *testing.T) {
 
 	// splitNonEmpty trims whitespace from each part
 	assert.Equal(t, []string{"lan", "opt1"}, device.InterfaceGroups[0].Members)
+}
+
+// TestBridges_EndToEnd_PlaceholderAndRealBridge drives real config.xml content
+// through the full parse -> convert -> statistics path. The <bridged> tag fix in
+// pkg/schema/opnsense made this path reachable for the first time, so the
+// end-to-end bridge count is asserted here rather than only at the schema layer.
+func TestBridges_EndToEnd_PlaceholderAndRealBridge(t *testing.T) {
+	t.Parallel()
+
+	const configTemplate = `<?xml version="1.0"?>
+<opnsense>
+  <system>
+    <hostname>fw</hostname>
+    <domain>example.com</domain>
+  </system>
+  <bridges>%s</bridges>
+</opnsense>`
+
+	tests := []struct {
+		name         string
+		bridgesInner string
+		wantBridges  int
+		wantBridgeIf string
+	}{
+		{
+			// OPNsense writes this placeholder when no bridge is configured.
+			name:         "empty bridged placeholder reports zero bridges",
+			bridgesInner: `<bridged/>`,
+			wantBridges:  0,
+		},
+		{
+			name:         "populated bridged element is counted",
+			bridgesInner: `<bridged><bridgeif>bridge0</bridgeif><members>opt1,opt2</members></bridged>`,
+			wantBridges:  1,
+			wantBridgeIf: "bridge0",
+		},
+	}
+
+	factory := parser.NewFactory(cfgparser.NewXMLParser())
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			xmlBody := strings.Replace(configTemplate, "%s", tt.bridgesInner, 1)
+			device, _, err := factory.CreateDevice(
+				context.Background(),
+				strings.NewReader(xmlBody),
+				common.DeviceTypeUnknown,
+				false,
+			)
+			require.NoError(t, err)
+			require.NotNil(t, device)
+
+			assert.Len(t, device.Bridges, tt.wantBridges)
+
+			stats := analysis.ComputeStatistics(device)
+			assert.Equal(t, tt.wantBridges, stats.TotalBridges,
+				"TotalBridges must not count empty <bridged/> placeholders")
+
+			if tt.wantBridgeIf != "" {
+				require.Len(t, device.Bridges, 1)
+				assert.Equal(t, tt.wantBridgeIf, device.Bridges[0].BridgeIf)
+			}
+		})
+	}
 }

--- a/pkg/parser/opnsense/converter_network_test.go
+++ b/pkg/parser/opnsense/converter_network_test.go
@@ -597,11 +597,11 @@ func TestConverter_InterfaceGroups_SpaceSeparated(t *testing.T) {
 	assert.Equal(t, []string{"lan", "opt1"}, device.InterfaceGroups[0].Members)
 }
 
-// TestBridges_EndToEnd_PlaceholderAndRealBridge drives real config.xml content
+// TestConverter_Bridges_EndToEnd_PlaceholderNotCounted drives real config.xml content
 // through the full parse -> convert -> statistics path. The <bridged> tag fix in
 // pkg/schema/opnsense made this path reachable for the first time, so the
 // end-to-end bridge count is asserted here rather than only at the schema layer.
-func TestBridges_EndToEnd_PlaceholderAndRealBridge(t *testing.T) {
+func TestConverter_Bridges_EndToEnd_PlaceholderNotCounted(t *testing.T) {
 	t.Parallel()
 
 	const configTemplate = `<?xml version="1.0"?>

--- a/pkg/schema/opnsense/interfaces.go
+++ b/pkg/schema/opnsense/interfaces.go
@@ -226,7 +226,7 @@ type VLAN struct {
 // Bridge represents a network bridge configuration, combining multiple interfaces
 // into a single Layer 2 broadcast domain with optional STP (Spanning Tree Protocol).
 type Bridge struct {
-	XMLName  xml.Name `xml:"bridge"`
+	XMLName  xml.Name `xml:"bridged"`
 	Members  string   `xml:"members,omitempty"`
 	Descr    string   `xml:"descr,omitempty"`
 	Bridgeif string   `xml:"bridgeif,omitempty"`
@@ -236,9 +236,10 @@ type Bridge struct {
 }
 
 // Bridges represents the <bridges> container element holding all bridge configurations.
+// OPNsense stores each entry as <bridged>, not <bridge>.
 type Bridges struct {
 	XMLName xml.Name `xml:"bridges"`
-	Bridge  []Bridge `xml:"bridge,omitempty"`
+	Bridge  []Bridge `xml:"bridged,omitempty"`
 }
 
 // GIF represents a GIF (Generic Tunnel Interface) configuration entry for IPv4/IPv6-in-IPv4/IPv6 tunneling.

--- a/pkg/schema/opnsense/interfaces_test.go
+++ b/pkg/schema/opnsense/interfaces_test.go
@@ -10,6 +10,27 @@ const testInterfaceDevice = "em0"
 // TestInterfaces_MarshalUnmarshal_Simple tests XML round-trip for Interfaces.
 //
 
+func TestBridges_UnmarshalBridgedElements(t *testing.T) {
+	t.Parallel()
+	const raw = `<bridges>
+  <bridged>
+    <bridgeif>bridge0</bridgeif>
+    <members>opt1,opt2</members>
+    <descr>LAN</descr>
+  </bridged>
+</bridges>`
+	var got Bridges
+	if err := xml.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(got.Bridge) != 1 {
+		t.Fatalf("got %d bridges, want 1", len(got.Bridge))
+	}
+	if got.Bridge[0].Bridgeif != "bridge0" {
+		t.Fatalf("bridgeif = %q", got.Bridge[0].Bridgeif)
+	}
+}
+
 func TestInterfaces_MarshalUnmarshal_Simple(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/schema/opnsense/interfaces_test.go
+++ b/pkg/schema/opnsense/interfaces_test.go
@@ -2,21 +2,24 @@ package opnsense
 
 import (
 	"encoding/xml"
+	"strings"
 	"testing"
 )
 
 const testInterfaceDevice = "em0"
 
-// TestInterfaces_MarshalUnmarshal_Simple tests XML round-trip for Interfaces.
-//
-
-func TestBridges_UnmarshalBridgedElements(t *testing.T) {
+// TestBridges_BridgedElementRoundTrip verifies that OPNsense <bridged> elements
+// unmarshal into Bridges and that the same element name is emitted on the way
+// back out. The struct tag governs both directions, so marshal is asserted
+// alongside unmarshal rather than left unpinned.
+func TestBridges_BridgedElementRoundTrip(t *testing.T) {
 	t.Parallel()
 	const raw = `<bridges>
   <bridged>
     <bridgeif>bridge0</bridgeif>
     <members>opt1,opt2</members>
     <descr>LAN</descr>
+    <stp>1</stp>
   </bridged>
 </bridges>`
 	var got Bridges
@@ -26,11 +29,52 @@ func TestBridges_UnmarshalBridgedElements(t *testing.T) {
 	if len(got.Bridge) != 1 {
 		t.Fatalf("got %d bridges, want 1", len(got.Bridge))
 	}
-	if got.Bridge[0].Bridgeif != "bridge0" {
-		t.Fatalf("bridgeif = %q", got.Bridge[0].Bridgeif)
+	assertBridgeFields(t, "unmarshal", got.Bridge[0])
+
+	data, err := xml.Marshal(&got)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	out := string(data)
+	if !strings.Contains(out, "<bridged>") {
+		t.Fatalf("marshal did not emit <bridged>: %s", out)
+	}
+	// "<bridge>" cannot match "<bridged>", so this catches a regression to the
+	// pre-fix element name.
+	if strings.Contains(out, "<bridge>") {
+		t.Fatalf("marshal emitted the pre-fix <bridge> element: %s", out)
+	}
+
+	var back Bridges
+	if err := xml.Unmarshal(data, &back); err != nil {
+		t.Fatalf("unmarshal after marshal: %v", err)
+	}
+	if len(back.Bridge) != 1 {
+		t.Fatalf("after round-trip got %d bridges, want 1", len(back.Bridge))
+	}
+	assertBridgeFields(t, "round-trip", back.Bridge[0])
+}
+
+// assertBridgeFields checks every field the round-trip fixture populates, so a
+// tag or marshaler regression on any one of them fails loudly.
+func assertBridgeFields(t *testing.T, stage string, b Bridge) {
+	t.Helper()
+
+	if b.Bridgeif != "bridge0" {
+		t.Errorf("%s: bridgeif = %q, want %q", stage, b.Bridgeif, "bridge0")
+	}
+	if b.Members != "opt1,opt2" {
+		t.Errorf("%s: members = %q, want %q", stage, b.Members, "opt1,opt2")
+	}
+	if b.Descr != "LAN" {
+		t.Errorf("%s: descr = %q, want %q", stage, b.Descr, "LAN")
+	}
+	if !bool(b.STP) {
+		t.Errorf("%s: stp = false, want true", stage)
 	}
 }
 
+// TestInterfaces_MarshalUnmarshal_Simple tests XML round-trip for Interfaces.
 func TestInterfaces_MarshalUnmarshal_Simple(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Description

OPNsense writes each bridge as `<bridged>` inside `<bridges>`. The schema looked for `<bridge>`, so `encoding/xml` never populated the slice. `convertBridges` returned early and `TotalBridges` was always zero.

This changes the container and `XMLName` tags to `bridged` and adds a fixture with a populated entry (the empty `<bridged/>` marker in the sample config is why this stayed invisible).

## Type of Change

- [x] **Bug fix** (non-breaking change which fixes an issue)

## Related Issues

Fixes #778

## Testing

```
go test ./pkg/schema/opnsense/ -count=1
```

`TestBridges_UnmarshalBridgedElements` and the existing schema tests pass.